### PR TITLE
Fix value getters for Projects table columns

### DIFF
--- a/frontend/src/pages/Projects/Projects.view.tsx
+++ b/frontend/src/pages/Projects/Projects.view.tsx
@@ -11,7 +11,7 @@ import {
   Stack,
   Typography
 } from '@mui/material'
-import { DataGrid, GridColDef, GridRenderCellParams, GridValueGetter } from '@mui/x-data-grid'
+import { DataGrid, GridColDef, GridRenderCellParams, GridValueGetterParams } from '@mui/x-data-grid'
 import { useTranslation } from 'react-i18next'
 import { useProjectsViewModel } from './Projects.viewmodel'
 import { useNavigate } from 'react-router-dom'
@@ -78,7 +78,7 @@ export default function ProjectsView() {
       field: 'role',
       headerName: t('projects.columns.role'),
       width: 180,
-      valueGetter: ((value, row) => row.roleLabel) as GridValueGetter<ProjectRow>,
+      valueGetter: (params: GridValueGetterParams<ProjectRow>) => params.row.roleLabel,
       renderCell: (params: GridRenderCellParams<ProjectRow>) => (
         <Chip
           label={params.row.roleLabel}
@@ -107,7 +107,7 @@ export default function ProjectsView() {
       field: 'risk',
       headerName: t('projects.columns.risk'),
       width: 160,
-      valueGetter: ((value, row) => row.riskLabel) as GridValueGetter<ProjectRow>,
+      valueGetter: (params: GridValueGetterParams<ProjectRow>) => params.row.riskLabel,
       renderCell: (params: GridRenderCellParams<ProjectRow>) => (
         <Chip
           label={params.row.riskLabel}
@@ -121,7 +121,7 @@ export default function ProjectsView() {
       field: 'docStatus',
       headerName: t('projects.columns.docStatus'),
       width: 160,
-      valueGetter: ((value, row) => row.docLabel) as GridValueGetter<ProjectRow>,
+      valueGetter: (params: GridValueGetterParams<ProjectRow>) => params.row.docLabel,
       renderCell: (params: GridRenderCellParams<ProjectRow>) => (
         <Chip
           label={params.row.docLabel}


### PR DESCRIPTION
## Summary
- update Projects table value getter callbacks to use typed params and translated labels directly

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7fa0a2d0883328511f41e975ab5ee