### PR TITLE
Add authentication flows for login and sign-in

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,11 +11,18 @@ import ProjectsWizardView from './pages/Projects/ProjectsWizard.view'
 import OrgRolesView from './pages/OrgRoles/OrgRoles.view'
 import AuditEvidencesView from './pages/AuditEvidences/AuditEvidences.view'
 import SettingsView from './pages/Settings/Settings.view'
+import AuthLayout from './pages/Auth/AuthLayout.view'
+import LoginView from './pages/Auth/Login.view'
+import SignInView from './pages/Auth/SignIn.view'
 
 export default function App() {
   return (
-    <AppShell>
-      <Routes>
+    <Routes>
+      <Route element={<AuthLayout />}>
+        <Route path="/login" element={<LoginView />} />
+        <Route path="/sign-in" element={<SignInView />} />
+      </Route>
+      <Route element={<AppShell />}>
         <Route path="/" element={<DashboardView />} />
         <Route path="/projects" element={<ProjectsView />} />
         <Route path="/projects/new" element={<ProjectsWizardView />} />
@@ -27,7 +34,7 @@ export default function App() {
         <Route path="/systems/:id" element={<SystemDetailView />} />
         <Route path="/incidents" element={<IncidentsView />} />
         <Route path="/settings" element={<SettingsView />} />
-      </Routes>
-    </AppShell>
+      </Route>
+    </Routes>
   )
 }

--- a/frontend/src/pages/Auth/AuthLayout.view.tsx
+++ b/frontend/src/pages/Auth/AuthLayout.view.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Box, Container } from '@mui/material'
+import { Outlet } from 'react-router-dom'
+
+export default function AuthLayout() {
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        bgcolor: (theme) => theme.palette.background.default,
+        py: { xs: 4, md: 8 }
+      }}
+    >
+      <Container maxWidth="sm">
+        <Outlet />
+      </Container>
+    </Box>
+  )
+}

--- a/frontend/src/pages/Auth/Login.view.tsx
+++ b/frontend/src/pages/Auth/Login.view.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from 'react'
+import {
+  Alert,
+  Button,
+  Divider,
+  Link,
+  Paper,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { login, loginWithSSO } from '../../services/auth'
+
+export default function LoginView() {
+  const { t } = useTranslation()
+  const [form, setForm] = useState({ company: '', email: '', password: '' })
+  const [loading, setLoading] = useState(false)
+  const [ssoLoading, setSsoLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const handleChange = (field: 'company' | 'email' | 'password') =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setForm(prev => ({ ...prev, [field]: event.target.value }))
+    }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setLoading(true)
+    setSsoLoading(false)
+    setError(null)
+    setSuccess(null)
+    try {
+      const response = await login({
+        company: form.company.trim(),
+        email: form.email.trim(),
+        password: form.password
+      })
+      setSuccess(t('auth.feedback.loginSuccess', { name: response.user.full_name }))
+    } catch (err) {
+      console.error(err)
+      setError(t('auth.feedback.loginError'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSSO = async () => {
+    setSsoLoading(true)
+    setLoading(false)
+    setError(null)
+    setSuccess(null)
+    try {
+      const response = await loginWithSSO({
+        company: form.company.trim(),
+        email: form.email.trim(),
+        provider: 'sso'
+      })
+      setSuccess(
+        t('auth.feedback.ssoSuccess', {
+          name: response.user.full_name,
+          provider: t('auth.login.ssoLabel')
+        })
+      )
+    } catch (err) {
+      console.error(err)
+      setError(t('auth.feedback.ssoError'))
+    } finally {
+      setSsoLoading(false)
+    }
+  }
+
+  const isSSOEnabled = form.company.trim().length > 0 && form.email.trim().length > 0
+
+  return (
+    <Paper elevation={4} sx={{ p: { xs: 3, md: 4 }, borderRadius: 3 }}>
+      <Stack spacing={3} component="form" onSubmit={handleSubmit}>
+        <Stack spacing={0.5}>
+          <Typography variant="h4" fontWeight={600}>
+            {t('auth.login.title')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t('auth.login.subtitle')}
+          </Typography>
+        </Stack>
+
+        {error && <Alert severity="error">{error}</Alert>}
+        {success && <Alert severity="success">{success}</Alert>}
+
+        <Stack spacing={2}>
+          <TextField
+            label={t('auth.fields.company')}
+            value={form.company}
+            onChange={handleChange('company')}
+            required
+            autoComplete="organization"
+            fullWidth
+          />
+          <TextField
+            label={t('auth.fields.email')}
+            value={form.email}
+            onChange={handleChange('email')}
+            type="email"
+            required
+            autoComplete="email"
+            fullWidth
+          />
+          <TextField
+            label={t('auth.fields.password')}
+            value={form.password}
+            onChange={handleChange('password')}
+            type="password"
+            required
+            autoComplete="current-password"
+            fullWidth
+          />
+        </Stack>
+
+        <Button type="submit" variant="contained" size="large" disabled={loading}>
+          {t('auth.login.submit')}
+        </Button>
+
+        <Divider>{t('auth.login.or')}</Divider>
+
+        <Button
+          variant="outlined"
+          size="large"
+          onClick={handleSSO}
+          disabled={!isSSOEnabled || ssoLoading}
+        >
+          {t('auth.login.ssoButton')}
+        </Button>
+
+        <Typography variant="body2" color="text.secondary" textAlign="center">
+          {t('auth.login.ssoHint')}
+        </Typography>
+
+        <Typography variant="body2" textAlign="center">
+          {t('auth.login.noAccount')}{' '}
+          <Link component={RouterLink} to="/sign-in">
+            {t('auth.login.goToSignUp')}
+          </Link>
+        </Typography>
+      </Stack>
+    </Paper>
+  )
+}

--- a/frontend/src/pages/Auth/SignIn.view.tsx
+++ b/frontend/src/pages/Auth/SignIn.view.tsx
@@ -1,0 +1,238 @@
+import React, { useMemo, useState } from 'react'
+import {
+  Alert,
+  Avatar,
+  Button,
+  Grid,
+  Link,
+  Paper,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography
+} from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { signIn } from '../../services/auth'
+
+type ContactMethod = 'email' | 'sms' | 'whatsapp' | 'slack'
+
+const contactMethods: ContactMethod[] = ['email', 'sms', 'whatsapp', 'slack']
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(new Error('Unable to read file'))
+    reader.readAsDataURL(file)
+  })
+}
+
+export default function SignInView() {
+  const { t } = useTranslation()
+  const [fullName, setFullName] = useState('')
+  const [email, setEmail] = useState('')
+  const [contactMethod, setContactMethod] = useState<ContactMethod>('email')
+  const [contactValue, setContactValue] = useState('')
+  const [slackWorkspace, setSlackWorkspace] = useState('')
+  const [slackChannel, setSlackChannel] = useState('')
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
+  const [avatarData, setAvatarData] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [temporaryPassword, setTemporaryPassword] = useState<string | null>(null)
+
+  const contactLabel = useMemo(() => {
+    if (contactMethod === 'email') return t('auth.signup.contactEmail')
+    if (contactMethod === 'sms') return t('auth.signup.contactPhoneSms')
+    if (contactMethod === 'whatsapp') return t('auth.signup.contactPhoneWhatsapp')
+    return t('auth.signup.contactSlackUser')
+  }, [contactMethod, t])
+
+  const handleContactMethod = (_: React.MouseEvent<HTMLElement>, value: ContactMethod | null) => {
+    if (!value) return
+    setContactMethod(value)
+    setContactValue('')
+    setSlackWorkspace('')
+    setSlackChannel('')
+  }
+
+  const handleAvatarChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) {
+      setAvatarPreview(null)
+      setAvatarData(null)
+      return
+    }
+
+    try {
+      const base64 = await fileToBase64(file)
+      setAvatarPreview(base64)
+      setAvatarData(base64)
+    } catch (err) {
+      console.error(err)
+      setError(t('auth.feedback.avatarError'))
+    }
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setLoading(true)
+    setError(null)
+    setSuccess(null)
+    setTemporaryPassword(null)
+
+    try {
+      const contact = {
+        method: contactMethod,
+        value: contactValue.trim(),
+        workspace: contactMethod === 'slack' ? slackWorkspace.trim() || undefined : undefined,
+        channel: contactMethod === 'slack' ? slackChannel.trim() || undefined : undefined
+      }
+
+      const response = await signIn({
+        full_name: fullName.trim(),
+        email: email.trim(),
+        contact,
+        avatar: avatarData ?? undefined
+      })
+
+      setSuccess(t('auth.feedback.signUpSuccess', { name: response.user.full_name }))
+      setTemporaryPassword(response.temporary_password)
+    } catch (err) {
+      console.error(err)
+      setError(t('auth.feedback.signUpError'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const isFormValid =
+    fullName.trim().length > 0 &&
+    email.trim().length > 0 &&
+    (contactMethod === 'slack'
+      ? slackWorkspace.trim().length > 0 && slackChannel.trim().length > 0
+      : contactValue.trim().length > 0)
+
+  return (
+    <Paper elevation={4} sx={{ p: { xs: 3, md: 4 }, borderRadius: 3 }}>
+      <Stack spacing={3} component="form" onSubmit={handleSubmit}>
+        <Stack spacing={0.5}>
+          <Typography variant="h4" fontWeight={600}>
+            {t('auth.signup.title')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t('auth.signup.subtitle')}
+          </Typography>
+        </Stack>
+
+        {error && <Alert severity="error">{error}</Alert>}
+        {success && <Alert severity="success">{success}</Alert>}
+        {temporaryPassword && (
+          <Alert severity="info">{t('auth.feedback.temporaryPassword', { password: temporaryPassword })}</Alert>
+        )}
+
+        <Stack spacing={2}>
+          <TextField
+            label={t('auth.signup.fullName')}
+            value={fullName}
+            onChange={(event) => setFullName(event.target.value)}
+            required
+            fullWidth
+          />
+          <TextField
+            label={t('auth.signup.email')}
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            type="email"
+            required
+            fullWidth
+          />
+        </Stack>
+
+        <Stack spacing={1.5}>
+          <Typography variant="subtitle2" color="text.secondary">
+            {t('auth.signup.contactLabel')}
+          </Typography>
+          <ToggleButtonGroup value={contactMethod} exclusive onChange={handleContactMethod} fullWidth>
+            {contactMethods.map(method => (
+              <ToggleButton key={method} value={method} aria-label={method}>
+                {t(`auth.contactMethods.${method}`)}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+
+          {contactMethod !== 'slack' && (
+            <TextField
+              label={contactLabel}
+              value={contactValue}
+              onChange={(event) => setContactValue(event.target.value)}
+              required
+              fullWidth
+            />
+          )}
+
+          {contactMethod === 'slack' && (
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label={t('auth.signup.slackWorkspace')}
+                  value={slackWorkspace}
+                  onChange={(event) => setSlackWorkspace(event.target.value)}
+                  required
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label={t('auth.signup.slackChannel')}
+                  value={slackChannel}
+                  onChange={(event) => setSlackChannel(event.target.value)}
+                  required
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  label={contactLabel}
+                  value={contactValue}
+                  onChange={(event) => setContactValue(event.target.value)}
+                  required
+                  fullWidth
+                />
+              </Grid>
+            </Grid>
+          )}
+        </Stack>
+
+        <Stack spacing={1} alignItems="flex-start">
+          <Typography variant="subtitle2" color="text.secondary">
+            {t('auth.signup.avatarLabel')}
+          </Typography>
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Avatar src={avatarPreview ?? undefined} sx={{ width: 64, height: 64 }}>
+              {fullName ? fullName[0]?.toUpperCase() : undefined}
+            </Avatar>
+            <Button variant="outlined" component="label">
+              {avatarPreview ? t('auth.signup.changeAvatar') : t('auth.signup.uploadAvatar')}
+              <input type="file" hidden accept="image/*" onChange={handleAvatarChange} />
+            </Button>
+          </Stack>
+        </Stack>
+
+        <Button type="submit" variant="contained" size="large" disabled={loading || !isFormValid}>
+          {t('auth.signup.submit')}
+        </Button>
+
+        <Typography variant="body2" textAlign="center">
+          {t('auth.signup.hasAccount')}{' '}
+          <Link component={RouterLink} to="/login">
+            {t('auth.signup.goToLogin')}
+          </Link>
+        </Typography>
+      </Stack>
+    </Paper>
+  )
+}

--- a/frontend/src/pages/Projects/Projects.view.tsx
+++ b/frontend/src/pages/Projects/Projects.view.tsx
@@ -11,7 +11,7 @@ import {
   Stack,
   Typography
 } from '@mui/material'
-import { DataGrid, GridColDef, GridRenderCellParams, GridValueGetterParams } from '@mui/x-data-grid'
+import { DataGrid, GridColDef, GridRenderCellParams, GridValueGetter } from '@mui/x-data-grid'
 import { useTranslation } from 'react-i18next'
 import { useProjectsViewModel } from './Projects.viewmodel'
 import { useNavigate } from 'react-router-dom'
@@ -30,6 +30,10 @@ type ProjectRow = AISystem & {
   riskLabel: string
   docLabel: string
 }
+
+const roleValueGetter: GridValueGetter<ProjectRow, string> = (_value, row) => row.roleLabel
+const riskValueGetter: GridValueGetter<ProjectRow, string> = (_value, row) => row.riskLabel
+const docValueGetter: GridValueGetter<ProjectRow, string> = (_value, row) => row.docLabel
 
 function resolveProjectState(system: AISystem): ProjectState {
   if (!system.docStatus || system.docStatus === 'na') return 'initial'
@@ -78,7 +82,7 @@ export default function ProjectsView() {
       field: 'role',
       headerName: t('projects.columns.role'),
       width: 180,
-      valueGetter: (params: GridValueGetterParams<ProjectRow>) => params.row.roleLabel,
+      valueGetter: roleValueGetter,
       renderCell: (params: GridRenderCellParams<ProjectRow>) => (
         <Chip
           label={params.row.roleLabel}
@@ -107,7 +111,7 @@ export default function ProjectsView() {
       field: 'risk',
       headerName: t('projects.columns.risk'),
       width: 160,
-      valueGetter: (params: GridValueGetterParams<ProjectRow>) => params.row.riskLabel,
+      valueGetter: riskValueGetter,
       renderCell: (params: GridRenderCellParams<ProjectRow>) => (
         <Chip
           label={params.row.riskLabel}
@@ -121,7 +125,7 @@ export default function ProjectsView() {
       field: 'docStatus',
       headerName: t('projects.columns.docStatus'),
       width: 160,
-      valueGetter: (params: GridValueGetterParams<ProjectRow>) => params.row.docLabel,
+      valueGetter: docValueGetter,
       renderCell: (params: GridRenderCellParams<ProjectRow>) => (
         <Chip
           label={params.row.docLabel}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,68 @@
+import { api } from './api'
+
+export interface ContactPreference {
+  method: 'email' | 'sms' | 'whatsapp' | 'slack'
+  value: string
+  workspace?: string
+  channel?: string
+}
+
+export interface User {
+  id: string
+  company?: string | null
+  full_name: string
+  email: string
+  contact: ContactPreference
+  avatar?: string | null
+}
+
+export interface LoginPayload {
+  company: string
+  email: string
+  password: string
+}
+
+export interface LoginResponse {
+  token: string
+  user: User
+}
+
+export interface SSOLoginPayload {
+  company: string
+  email: string
+  provider: string
+}
+
+export interface SignInPayload {
+  full_name: string
+  email: string
+  contact: ContactPreference
+  avatar?: string
+}
+
+export interface SignInResponse {
+  user: User
+  temporary_password: string
+  message: string
+}
+
+export function login(payload: LoginPayload) {
+  return api<LoginResponse>('/auth/login', {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  })
+}
+
+export function loginWithSSO(payload: SSOLoginPayload) {
+  return api<LoginResponse>('/auth/login/sso', {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  })
+}
+
+export function signIn(payload: SignInPayload) {
+  return api<SignInResponse>('/auth/sign-in', {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  })
+}

--- a/frontend/src/shared/AppShell.view.tsx
+++ b/frontend/src/shared/AppShell.view.tsx
@@ -24,7 +24,7 @@ import SearchIcon from '@mui/icons-material/Search'
 import { alpha, useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTranslation } from 'react-i18next'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, Outlet, useLocation } from 'react-router-dom'
 import { supportedLanguages, type SupportedLanguage } from './i18n'
 import { useProjectContext } from './project-context'
 
@@ -44,7 +44,7 @@ const userProfile = {
   initials: 'RS'
 }
 
-export default function AppShell({ children }: { children: React.ReactNode }) {
+export default function AppShell() {
   const [mobileOpen, setMobileOpen] = React.useState(false)
   const [search, setSearch] = React.useState('')
   const location = useLocation()
@@ -205,7 +205,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       </Box>
       <Box component="main" sx={{ flexGrow: 1 }}>
         <Toolbar />
-        <Container maxWidth="lg" sx={{ py: 3 }}>{children}</Container>
+        <Container maxWidth="lg" sx={{ py: 3 }}>
+          <Outlet />
+        </Container>
       </Box>
     </Box>
   )

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -33,6 +33,59 @@ const resources = {
           audit: "Auditoría"
         }
       },
+      auth: {
+        fields: {
+          company: "Empresa",
+          email: "Correo electrónico",
+          password: "Contraseña"
+        },
+        login: {
+          title: "Inicia sesión",
+          subtitle: "Accede al panel de cumplimiento con tus credenciales corporativas.",
+          submit: "Entrar",
+          or: "o",
+          ssoButton: "Continuar con SSO corporativo",
+          ssoHint: "El acceso SSO requiere una suscripción activa de tu organización.",
+          ssoLabel: "SSO corporativo",
+          noAccount: "¿Aún no tienes cuenta?",
+          goToSignUp: "Crear una nueva cuenta"
+        },
+        signup: {
+          title: "Crea tu cuenta",
+          subtitle: "Registra tu equipo para comenzar a gestionar el cumplimiento.",
+          fullName: "Nombre completo",
+          email: "Correo electrónico",
+          contactLabel: "Preferencia de contacto principal",
+          contactEmail: "Correo de contacto",
+          contactPhoneSms: "Número de móvil (SMS)",
+          contactPhoneWhatsapp: "Número de WhatsApp",
+          contactSlackUser: "Usuario o canal de Slack",
+          slackWorkspace: "Workspace de Slack",
+          slackChannel: "Canal o usuario",
+          avatarLabel: "Avatar (opcional)",
+          uploadAvatar: "Subir avatar",
+          changeAvatar: "Cambiar avatar",
+          submit: "Registrarme",
+          hasAccount: "¿Ya tienes cuenta?",
+          goToLogin: "Volver al login"
+        },
+        contactMethods: {
+          email: "Correo",
+          sms: "SMS",
+          whatsapp: "WhatsApp",
+          slack: "Slack"
+        },
+        feedback: {
+          loginSuccess: "Bienvenido/a de nuevo, {{name}}.",
+          loginError: "No se pudo iniciar sesión con esas credenciales.",
+          ssoSuccess: "Has accedido mediante {{provider}} como {{name}}.",
+          ssoError: "El inicio de sesión SSO ha fallado.",
+          signUpSuccess: "Registro completado para {{name}}.",
+          signUpError: "No se pudo completar el registro.",
+          temporaryPassword: "Tu contraseña temporal es: {{password}}",
+          avatarError: "No se pudo cargar la imagen seleccionada."
+        }
+      },
       deliverables: {
         title: "Entregables del Proyecto",
         columns: {
@@ -649,6 +702,59 @@ const resources = {
           audit: "Audit"
         }
       },
+      auth: {
+        fields: {
+          company: "Company",
+          email: "Email",
+          password: "Password"
+        },
+        login: {
+          title: "Sign in",
+          subtitle: "Access the compliance workspace with your corporate credentials.",
+          submit: "Sign in",
+          or: "or",
+          ssoButton: "Continue with corporate SSO",
+          ssoHint: "Corporate SSO requires an active subscription from your organization.",
+          ssoLabel: "Corporate SSO",
+          noAccount: "Don't have an account yet?",
+          goToSignUp: "Create a new account"
+        },
+        signup: {
+          title: "Create your account",
+          subtitle: "Register your team to start managing AI Act compliance.",
+          fullName: "Full name",
+          email: "Work email",
+          contactLabel: "Preferred contact method",
+          contactEmail: "Contact email",
+          contactPhoneSms: "Mobile number (SMS)",
+          contactPhoneWhatsapp: "WhatsApp number",
+          contactSlackUser: "Slack user or channel",
+          slackWorkspace: "Slack workspace",
+          slackChannel: "Channel or user",
+          avatarLabel: "Avatar (optional)",
+          uploadAvatar: "Upload avatar",
+          changeAvatar: "Change avatar",
+          submit: "Create account",
+          hasAccount: "Already have an account?",
+          goToLogin: "Back to login"
+        },
+        contactMethods: {
+          email: "Email",
+          sms: "SMS",
+          whatsapp: "WhatsApp",
+          slack: "Slack"
+        },
+        feedback: {
+          loginSuccess: "Welcome back, {{name}}.",
+          loginError: "We couldn't sign you in with those credentials.",
+          ssoSuccess: "Signed in with {{provider}} as {{name}}.",
+          ssoError: "SSO sign-in failed.",
+          signUpSuccess: "Registration completed for {{name}}.",
+          signUpError: "We couldn't finish the registration.",
+          temporaryPassword: "Your temporary password is: {{password}}",
+          avatarError: "We couldn't process the selected image."
+        }
+      },
       deliverables: {
         title: "Project Deliverables",
         columns: {
@@ -1114,6 +1220,59 @@ const resources = {
           audit: "Auditoria"
         }
       },
+      auth: {
+        fields: {
+          company: "Empresa",
+          email: "Correu electrònic",
+          password: "Contrasenya"
+        },
+        login: {
+          title: "Inicia sessió",
+          subtitle: "Accedeix a l'entorn de compliment amb les teves credencials corporatives.",
+          submit: "Entrar",
+          or: "o",
+          ssoButton: "Continua amb SSO corporatiu",
+          ssoHint: "L'SSO corporatiu requereix una subscripció activa de l'organització.",
+          ssoLabel: "SSO corporatiu",
+          noAccount: "Encara no tens compte?",
+          goToSignUp: "Crear un nou compte"
+        },
+        signup: {
+          title: "Crea el teu compte",
+          subtitle: "Registra el teu equip per començar a gestionar el compliment de l'AI Act.",
+          fullName: "Nom complet",
+          email: "Correu electrònic",
+          contactLabel: "Mètode de contacte preferit",
+          contactEmail: "Correu de contacte",
+          contactPhoneSms: "Número mòbil (SMS)",
+          contactPhoneWhatsapp: "Número de WhatsApp",
+          contactSlackUser: "Usuari o canal de Slack",
+          slackWorkspace: "Workspace de Slack",
+          slackChannel: "Canal o usuari",
+          avatarLabel: "Avatar (opcional)",
+          uploadAvatar: "Puja un avatar",
+          changeAvatar: "Canvia l'avatar",
+          submit: "Registrar-me",
+          hasAccount: "Ja tens compte?",
+          goToLogin: "Torna al login"
+        },
+        contactMethods: {
+          email: "Correu",
+          sms: "SMS",
+          whatsapp: "WhatsApp",
+          slack: "Slack"
+        },
+        feedback: {
+          loginSuccess: "Benvingut/da de nou, {{name}}.",
+          loginError: "No s'ha pogut iniciar sessió amb aquestes credencials.",
+          ssoSuccess: "Sessió iniciada amb {{provider}} com a {{name}}.",
+          ssoError: "Error en l'inici de sessió SSO.",
+          signUpSuccess: "Registre completat per {{name}}.",
+          signUpError: "No s'ha pogut completar el registre.",
+          temporaryPassword: "La teva contrasenya temporal és: {{password}}",
+          avatarError: "No s'ha pogut carregar la imatge seleccionada."
+        }
+      },
       deliverables: {
         title: "Lliurables del Projecte",
         columns: {
@@ -1577,6 +1736,59 @@ const resources = {
           calendar: "Calendrier",
           org: "Org & Rôles",
           audit: "Audit"
+        }
+      },
+      auth: {
+        fields: {
+          company: "Entreprise",
+          email: "E-mail",
+          password: "Mot de passe"
+        },
+        login: {
+          title: "Connexion",
+          subtitle: "Accédez à la plateforme de conformité avec vos identifiants d'entreprise.",
+          submit: "Se connecter",
+          or: "ou",
+          ssoButton: "Continuer avec le SSO d'entreprise",
+          ssoHint: "Le SSO d'entreprise nécessite un abonnement actif de votre organisation.",
+          ssoLabel: "SSO d'entreprise",
+          noAccount: "Pas encore de compte ?",
+          goToSignUp: "Créer un compte"
+        },
+        signup: {
+          title: "Créer votre compte",
+          subtitle: "Inscrivez votre équipe pour gérer la conformité à l'AI Act.",
+          fullName: "Nom complet",
+          email: "E-mail professionnel",
+          contactLabel: "Méthode de contact préférée",
+          contactEmail: "E-mail de contact",
+          contactPhoneSms: "Numéro de mobile (SMS)",
+          contactPhoneWhatsapp: "Numéro WhatsApp",
+          contactSlackUser: "Utilisateur ou canal Slack",
+          slackWorkspace: "Espace de travail Slack",
+          slackChannel: "Canal ou utilisateur",
+          avatarLabel: "Avatar (optionnel)",
+          uploadAvatar: "Télécharger un avatar",
+          changeAvatar: "Modifier l'avatar",
+          submit: "Créer le compte",
+          hasAccount: "Vous avez déjà un compte ?",
+          goToLogin: "Retour au login"
+        },
+        contactMethods: {
+          email: "E-mail",
+          sms: "SMS",
+          whatsapp: "WhatsApp",
+          slack: "Slack"
+        },
+        feedback: {
+          loginSuccess: "Bon retour, {{name}}.",
+          loginError: "Impossible de vous connecter avec ces identifiants.",
+          ssoSuccess: "Connecté avec {{provider}} en tant que {{name}}.",
+          ssoError: "La connexion SSO a échoué.",
+          signUpSuccess: "Inscription terminée pour {{name}}.",
+          signUpError: "Impossible de finaliser l'inscription.",
+          temporaryPassword: "Votre mot de passe temporaire est : {{password}}",
+          avatarError: "Impossible de traiter l'image sélectionnée."
         }
       },
       deliverables: {


### PR DESCRIPTION
## Summary
- add FastAPI models, stores, and endpoints for login, SSO, and sign-in flows
- implement React login/sign-in pages with dedicated layout, routing updates, and auth service
- extend translations and adjust projects grid typings to satisfy the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d808fc57148332b961fea9f1d11346