### PR TITLE
Refactor FastAPI schemas into dedicated modules

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,236 +1,45 @@
 import secrets
 from collections import defaultdict
-from enum import Enum
 from typing import Dict, List, Optional
 from uuid import uuid4
 
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+
+from backend.schemas import (
+    AISystem,
+    AISystemUpdate,
+    Audit,
+    Contact,
+    ContactMethod,
+    ContactPreference,
+    DashboardOverview,
+    Deliverable,
+    DeliverableAssignment,
+    DeliverableTemplate,
+    DeliverableUpdate,
+    Evidence,
+    Incident,
+    IncidentUpdate,
+    LoginPayload,
+    LoginResult,
+    OrgStructure,
+    PendingActivity,
+    RACIEntry,
+    RiskAssessment,
+    RiskWizardConfig,
+    Settings,
+    SignInPayload,
+    SignInResponse,
+    SSOLoginPayload,
+    Task,
+    TaskUpdate,
+    TeamMember,
+    TechnicalDossier,
+    TechnicalDossierTemplate,
+    User,
+)
 
 app = FastAPI(title="AI Act Compliance Manager API", version="0.1.0")
-
-
-# ---------------------------------------------------------------------------
-# Data models
-# ---------------------------------------------------------------------------
-
-
-class AISystem(BaseModel):
-    id: str
-    name: str
-    role: str  # provider/importer/distributor/user
-    risk: Optional[str] = None
-    documentation_status: Optional[str] = None
-    business_units: Optional[List[str]] = None
-    team: Optional[List[str]] = None
-
-
-class AISystemUpdate(BaseModel):
-    name: Optional[str] = None
-    role: Optional[str] = None
-    risk: Optional[str] = None
-    documentation_status: Optional[str] = None
-    business_units: Optional[List[str]] = None
-    team: Optional[List[str]] = None
-
-
-class RiskWizardConfig(BaseModel):
-    steps: List[Dict[str, str]] = []
-
-
-class RiskAssessment(BaseModel):
-    id: str
-    system_id: str
-    date: str
-    classification: str
-    justification: Optional[str] = None
-
-
-class DeliverableTemplate(BaseModel):
-    id: str
-    name: str
-    type: str
-
-
-class Deliverable(BaseModel):
-    id: str
-    system_id: str
-    name: str
-    version: Optional[str] = None
-    status: Optional[str] = None
-    link: Optional[str] = None
-
-
-class DeliverableUpdate(BaseModel):
-    version: Optional[str] = None
-    status: Optional[str] = None
-    link: Optional[str] = None
-
-
-class DeliverableAssignment(BaseModel):
-    assignee: str
-    due_date: Optional[str] = None
-
-
-class Task(BaseModel):
-    id: str
-    system_id: str
-    title: str
-    status: str
-    assignee: Optional[str] = None
-    due_date: Optional[str] = None
-
-
-class TaskUpdate(BaseModel):
-    title: Optional[str] = None
-    status: Optional[str] = None
-    assignee: Optional[str] = None
-    due_date: Optional[str] = None
-
-
-class Incident(BaseModel):
-    id: str
-    system_id: Optional[str] = None
-    severity: str
-    status: str
-    title: str
-    description: str
-
-
-class IncidentUpdate(BaseModel):
-    severity: Optional[str] = None
-    status: Optional[str] = None
-    title: Optional[str] = None
-    description: Optional[str] = None
-
-
-class Audit(BaseModel):
-    id: str
-    project_id: str
-    name: str
-    scope: str
-    date: str
-    status: str
-
-
-class Evidence(BaseModel):
-    id: str
-    project_id: str
-    type: str
-    system_id: Optional[str] = None
-    date: str
-    owner: Optional[str] = None
-
-
-class OrgStructure(BaseModel):
-    project_id: str
-    business_units: List[str] = []
-    contacts: List[str] = []
-
-
-class RACIEntry(BaseModel):
-    role: str
-    responsible: List[str]
-    accountable: List[str]
-    consulted: List[str]
-    informed: List[str]
-
-
-class Contact(BaseModel):
-    id: str
-    project_id: str
-    name: str
-    role: str
-    email: Optional[str] = None
-
-
-class DashboardOverview(BaseModel):
-    kpis: Dict[str, str] = {}
-    compliance_distribution: Dict[str, float] = {}
-    timeline: List[Dict[str, str]] = []
-    pending_actions: List[str] = []
-
-
-class Settings(BaseModel):
-    language: Optional[str] = None
-    theme: Optional[str] = None
-    notifications: Optional[List[str]] = None
-    api_key: Optional[str] = None
-
-
-class TechnicalDossierTemplate(BaseModel):
-    sections: List[Dict[str, str]] = []
-
-
-class TechnicalDossier(BaseModel):
-    system_id: str
-    fields: Dict[str, str] = {}
-
-
-class TeamMember(BaseModel):
-    id: str
-    system_id: str
-    name: str
-    role: str
-
-
-class PendingActivity(BaseModel):
-    id: str
-    description: str
-    due_date: Optional[str] = None
-
-
-class ContactMethod(str, Enum):
-    email = "email"
-    sms = "sms"
-    whatsapp = "whatsapp"
-    slack = "slack"
-
-
-class ContactPreference(BaseModel):
-    method: ContactMethod
-    value: str
-    workspace: Optional[str] = None
-    channel: Optional[str] = None
-
-
-class User(BaseModel):
-    id: str
-    company: Optional[str] = None
-    full_name: str
-    email: str
-    contact: ContactPreference
-    avatar: Optional[str] = None
-
-
-class LoginPayload(BaseModel):
-    company: str
-    email: str
-    password: str
-
-
-class SSOLoginPayload(BaseModel):
-    company: str
-    email: str
-    provider: str
-
-
-class LoginResult(BaseModel):
-    token: str
-    user: User
-
-
-class SignInPayload(BaseModel):
-    full_name: str
-    email: str
-    contact: ContactPreference
-    avatar: Optional[str] = None
-
-
-class SignInResponse(BaseModel):
-    user: User
-    temporary_password: str
-    message: str
 
 
 # ---------------------------------------------------------------------------

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,0 +1,65 @@
+from .ai_system import AISystem
+from .ai_system_update import AISystemUpdate
+from .audit import Audit
+from .contact import Contact
+from .contact_method import ContactMethod
+from .contact_preference import ContactPreference
+from .dashboard_overview import DashboardOverview
+from .deliverable import Deliverable
+from .deliverable_assignment import DeliverableAssignment
+from .deliverable_template import DeliverableTemplate
+from .deliverable_update import DeliverableUpdate
+from .evidence import Evidence
+from .incident import Incident
+from .incident_update import IncidentUpdate
+from .login_payload import LoginPayload
+from .login_result import LoginResult
+from .org_structure import OrgStructure
+from .pending_activity import PendingActivity
+from .raci_entry import RACIEntry
+from .risk_assessment import RiskAssessment
+from .risk_wizard_config import RiskWizardConfig
+from .settings import Settings
+from .sign_in_payload import SignInPayload
+from .sign_in_response import SignInResponse
+from .sso_login_payload import SSOLoginPayload
+from .task import Task
+from .task_update import TaskUpdate
+from .team_member import TeamMember
+from .technical_dossier import TechnicalDossier
+from .technical_dossier_template import TechnicalDossierTemplate
+from .user import User
+
+__all__ = [
+    "AISystem",
+    "AISystemUpdate",
+    "Audit",
+    "Contact",
+    "ContactMethod",
+    "ContactPreference",
+    "DashboardOverview",
+    "Deliverable",
+    "DeliverableAssignment",
+    "DeliverableTemplate",
+    "DeliverableUpdate",
+    "Evidence",
+    "Incident",
+    "IncidentUpdate",
+    "LoginPayload",
+    "LoginResult",
+    "OrgStructure",
+    "PendingActivity",
+    "RACIEntry",
+    "RiskAssessment",
+    "RiskWizardConfig",
+    "Settings",
+    "SignInPayload",
+    "SignInResponse",
+    "SSOLoginPayload",
+    "Task",
+    "TaskUpdate",
+    "TeamMember",
+    "TechnicalDossier",
+    "TechnicalDossierTemplate",
+    "User",
+]

--- a/backend/schemas/ai_system.py
+++ b/backend/schemas/ai_system.py
@@ -1,0 +1,13 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class AISystem(BaseModel):
+    id: str
+    name: str
+    role: str  # provider/importer/distributor/user
+    risk: Optional[str] = None
+    documentation_status: Optional[str] = None
+    business_units: Optional[List[str]] = None
+    team: Optional[List[str]] = None

--- a/backend/schemas/ai_system_update.py
+++ b/backend/schemas/ai_system_update.py
@@ -1,0 +1,12 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class AISystemUpdate(BaseModel):
+    name: Optional[str] = None
+    role: Optional[str] = None
+    risk: Optional[str] = None
+    documentation_status: Optional[str] = None
+    business_units: Optional[List[str]] = None
+    team: Optional[List[str]] = None

--- a/backend/schemas/audit.py
+++ b/backend/schemas/audit.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class Audit(BaseModel):
+    id: str
+    project_id: str
+    name: str
+    scope: str
+    date: str
+    status: str

--- a/backend/schemas/contact.py
+++ b/backend/schemas/contact.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Contact(BaseModel):
+    id: str
+    project_id: str
+    name: str
+    role: str
+    email: Optional[str] = None

--- a/backend/schemas/contact_method.py
+++ b/backend/schemas/contact_method.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ContactMethod(str, Enum):
+    email = "email"
+    sms = "sms"
+    whatsapp = "whatsapp"
+    slack = "slack"

--- a/backend/schemas/contact_preference.py
+++ b/backend/schemas/contact_preference.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+from .contact_method import ContactMethod
+
+
+class ContactPreference(BaseModel):
+    method: ContactMethod
+    value: str
+    workspace: Optional[str] = None
+    channel: Optional[str] = None

--- a/backend/schemas/dashboard_overview.py
+++ b/backend/schemas/dashboard_overview.py
@@ -1,0 +1,10 @@
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class DashboardOverview(BaseModel):
+    kpis: Dict[str, str] = Field(default_factory=dict)
+    compliance_distribution: Dict[str, float] = Field(default_factory=dict)
+    timeline: List[Dict[str, str]] = Field(default_factory=list)
+    pending_actions: List[str] = Field(default_factory=list)

--- a/backend/schemas/deliverable.py
+++ b/backend/schemas/deliverable.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Deliverable(BaseModel):
+    id: str
+    system_id: str
+    name: str
+    version: Optional[str] = None
+    status: Optional[str] = None
+    link: Optional[str] = None

--- a/backend/schemas/deliverable_assignment.py
+++ b/backend/schemas/deliverable_assignment.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class DeliverableAssignment(BaseModel):
+    assignee: str
+    due_date: Optional[str] = None

--- a/backend/schemas/deliverable_template.py
+++ b/backend/schemas/deliverable_template.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class DeliverableTemplate(BaseModel):
+    id: str
+    name: str
+    type: str

--- a/backend/schemas/deliverable_update.py
+++ b/backend/schemas/deliverable_update.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class DeliverableUpdate(BaseModel):
+    version: Optional[str] = None
+    status: Optional[str] = None
+    link: Optional[str] = None

--- a/backend/schemas/evidence.py
+++ b/backend/schemas/evidence.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Evidence(BaseModel):
+    id: str
+    project_id: str
+    type: str
+    system_id: Optional[str] = None
+    date: str
+    owner: Optional[str] = None

--- a/backend/schemas/incident.py
+++ b/backend/schemas/incident.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Incident(BaseModel):
+    id: str
+    system_id: Optional[str] = None
+    severity: str
+    status: str
+    title: str
+    description: str

--- a/backend/schemas/incident_update.py
+++ b/backend/schemas/incident_update.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class IncidentUpdate(BaseModel):
+    severity: Optional[str] = None
+    status: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None

--- a/backend/schemas/login_payload.py
+++ b/backend/schemas/login_payload.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class LoginPayload(BaseModel):
+    company: str
+    email: str
+    password: str

--- a/backend/schemas/login_result.py
+++ b/backend/schemas/login_result.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+from .user import User
+
+
+class LoginResult(BaseModel):
+    token: str
+    user: User

--- a/backend/schemas/org_structure.py
+++ b/backend/schemas/org_structure.py
@@ -1,0 +1,9 @@
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class OrgStructure(BaseModel):
+    project_id: str
+    business_units: List[str] = Field(default_factory=list)
+    contacts: List[str] = Field(default_factory=list)

--- a/backend/schemas/pending_activity.py
+++ b/backend/schemas/pending_activity.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class PendingActivity(BaseModel):
+    id: str
+    description: str
+    due_date: Optional[str] = None

--- a/backend/schemas/raci_entry.py
+++ b/backend/schemas/raci_entry.py
@@ -1,0 +1,11 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class RACIEntry(BaseModel):
+    role: str
+    responsible: List[str]
+    accountable: List[str]
+    consulted: List[str]
+    informed: List[str]

--- a/backend/schemas/risk_assessment.py
+++ b/backend/schemas/risk_assessment.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class RiskAssessment(BaseModel):
+    id: str
+    system_id: str
+    date: str
+    classification: str
+    justification: Optional[str] = None

--- a/backend/schemas/risk_wizard_config.py
+++ b/backend/schemas/risk_wizard_config.py
@@ -1,0 +1,7 @@
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class RiskWizardConfig(BaseModel):
+    steps: List[Dict[str, str]] = Field(default_factory=list)

--- a/backend/schemas/settings.py
+++ b/backend/schemas/settings.py
@@ -1,0 +1,10 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class Settings(BaseModel):
+    language: Optional[str] = None
+    theme: Optional[str] = None
+    notifications: Optional[List[str]] = None
+    api_key: Optional[str] = None

--- a/backend/schemas/sign_in_payload.py
+++ b/backend/schemas/sign_in_payload.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+from .contact_preference import ContactPreference
+
+
+class SignInPayload(BaseModel):
+    full_name: str
+    email: str
+    contact: ContactPreference
+    avatar: Optional[str] = None

--- a/backend/schemas/sign_in_response.py
+++ b/backend/schemas/sign_in_response.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+from .user import User
+
+
+class SignInResponse(BaseModel):
+    user: User
+    temporary_password: str
+    message: str

--- a/backend/schemas/sso_login_payload.py
+++ b/backend/schemas/sso_login_payload.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class SSOLoginPayload(BaseModel):
+    company: str
+    email: str
+    provider: str

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Task(BaseModel):
+    id: str
+    system_id: str
+    title: str
+    status: str
+    assignee: Optional[str] = None
+    due_date: Optional[str] = None

--- a/backend/schemas/task_update.py
+++ b/backend/schemas/task_update.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class TaskUpdate(BaseModel):
+    title: Optional[str] = None
+    status: Optional[str] = None
+    assignee: Optional[str] = None
+    due_date: Optional[str] = None

--- a/backend/schemas/team_member.py
+++ b/backend/schemas/team_member.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class TeamMember(BaseModel):
+    id: str
+    system_id: str
+    name: str
+    role: str

--- a/backend/schemas/technical_dossier.py
+++ b/backend/schemas/technical_dossier.py
@@ -1,0 +1,8 @@
+from typing import Dict
+
+from pydantic import BaseModel, Field
+
+
+class TechnicalDossier(BaseModel):
+    system_id: str
+    fields: Dict[str, str] = Field(default_factory=dict)

--- a/backend/schemas/technical_dossier_template.py
+++ b/backend/schemas/technical_dossier_template.py
@@ -1,0 +1,7 @@
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class TechnicalDossierTemplate(BaseModel):
+    sections: List[Dict[str, str]] = Field(default_factory=list)

--- a/backend/schemas/user.py
+++ b/backend/schemas/user.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+from .contact_preference import ContactPreference
+
+
+class User(BaseModel):
+    id: str
+    company: Optional[str] = None
+    full_name: str
+    email: str
+    contact: ContactPreference
+    avatar: Optional[str] = None


### PR DESCRIPTION
## Summary
- move all Pydantic schemas from `main.py` into dedicated modules under `backend/schemas`
- add package exports so the FastAPI app imports the shared schemas cleanly
- adjust in-memory FastAPI app to rely on the centralized schema package

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d80d8745a0833292dcd148d517d309