### PR TITLE
Replace python-jose with PyJWT

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,8 @@ from uuid import uuid4
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
+import jwt
+from jwt import PyJWTError
 
 from backend.schemas import (
     AISystem,
@@ -66,7 +67,7 @@ def _decode_token(token: str) -> Dict[str, Any]:
     try:
         payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
         return payload
-    except JWTError as exc:
+    except PyJWTError as exc:
         raise HTTPException(status_code=401, detail="Invalid authentication credentials") from exc
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,4 +2,4 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.6
 pydantic==2.9.2
 python-dotenv==1.0.1
-python-jose[cryptography]==3.3.0
+PyJWT==2.9.0


### PR DESCRIPTION
## Summary
- switch the backend authentication helpers to use PyJWT instead of python-jose
- update backend dependencies to install PyJWT

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d81783b14c8332b67cf2802dbe80c2