### PR TITLE
Add database persistence for user management with encryption

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,61 @@
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+
+def _build_sqlite_url() -> str:
+    db_path = os.getenv("SQLITE_DB_PATH")
+    if db_path:
+        return f"sqlite:///{db_path}"
+    default_path = os.path.join(os.path.dirname(__file__), "data.db")
+    return f"sqlite:///{default_path}"
+
+
+DATABASE_URL = os.getenv("DATABASE_URL") or _build_sqlite_url()
+
+is_sqlite = DATABASE_URL.startswith("sqlite")
+
+engine_arguments = {"future": True}
+connect_args = {"check_same_thread": False} if is_sqlite else {}
+
+engine: Engine = create_engine(
+    DATABASE_URL,
+    connect_args=connect_args,
+    pool_pre_ping=True,
+    **engine_arguments,
+)
+
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+Base = declarative_base()
+
+
+def init_db() -> None:
+    from . import models  # noqa: F401 - ensure models are imported
+
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Iterator[Session]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+def generate_uuid() -> str:
+    return str(uuid4())
+
+
+class UserModel(Base):
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
+    company: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    full_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    avatar: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    contact: Mapped["ContactPreferenceModel" | None] = relationship(
+        "ContactPreferenceModel",
+        back_populates="user",
+        uselist=False,
+        cascade="all, delete-orphan",
+    )
+
+
+class ContactPreferenceModel(Base):
+    __tablename__ = "user_contact_preferences"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
+    user_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, unique=True
+    )
+    method: Mapped[str] = mapped_column(String(50), nullable=False)
+    value_encrypted: Mapped[str] = mapped_column(String(1024), nullable=False)
+    workspace_encrypted: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    channel_encrypted: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    user: Mapped[UserModel] = relationship("UserModel", back_populates="contact")

--- a/backend/repositories/__init__.py
+++ b/backend/repositories/__init__.py
@@ -1,0 +1,3 @@
+"""Repository layer for database persistence."""
+
+__all__ = ["user_repository"]

--- a/backend/repositories/user_repository.py
+++ b/backend/repositories/user_repository.py
@@ -1,0 +1,98 @@
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from backend.models import ContactPreferenceModel, UserModel
+from backend.schemas import ContactMethod, ContactPreference, User
+from backend.security import decrypt_value, encrypt_value, hash_password
+
+
+def _model_to_schema(model: UserModel) -> User:
+    contact_model = model.contact
+    if contact_model is None:
+        raise ValueError("User contact information is missing")
+
+    contact = ContactPreference(
+        method=ContactMethod(contact_model.method),
+        value=decrypt_value(contact_model.value_encrypted) or "",
+        workspace=decrypt_value(contact_model.workspace_encrypted),
+        channel=decrypt_value(contact_model.channel_encrypted),
+    )
+
+    return User(
+        id=model.id,
+        company=model.company,
+        full_name=model.full_name,
+        email=model.email,
+        contact=contact,
+        avatar=model.avatar,
+    )
+
+
+def get_user_by_id(db: Session, user_id: str) -> Optional[User]:
+    statement = select(UserModel).where(UserModel.id == user_id)
+    result = db.execute(statement).scalar_one_or_none()
+    if result is None:
+        return None
+    return _model_to_schema(result)
+
+
+def get_user_model_by_email(db: Session, email: str) -> Optional[UserModel]:
+    normalized = email.lower()
+    statement = select(UserModel).where(UserModel.email == normalized)
+    return db.execute(statement).scalar_one_or_none()
+
+
+def create_user(
+    db: Session,
+    *,
+    user_id: str,
+    company: Optional[str],
+    full_name: str,
+    email: str,
+    avatar: Optional[str],
+    contact: ContactPreference,
+    password: Optional[str] = None,
+) -> UserModel:
+    normalized_email = email.lower()
+    user_model = UserModel(
+        id=user_id,
+        company=company,
+        full_name=full_name,
+        email=normalized_email,
+        avatar=avatar,
+        password_hash=hash_password(password) if password else None,
+    )
+
+    contact_model = ContactPreferenceModel(
+        method=contact.method.value,
+        value_encrypted=encrypt_value(contact.value) or "",
+        workspace_encrypted=encrypt_value(contact.workspace),
+        channel_encrypted=encrypt_value(contact.channel),
+    )
+
+    user_model.contact = contact_model
+
+    db.add(user_model)
+    db.commit()
+    db.refresh(user_model)
+    return user_model
+
+
+def update_user_company(db: Session, user: UserModel, company: Optional[str]) -> None:
+    user.company = company
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+
+def update_user_password(db: Session, user: UserModel, password: str) -> None:
+    user.password_hash = hash_password(password)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+
+def model_to_schema(model: UserModel) -> User:
+    return _model_to_schema(model)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]==0.30.6
 pydantic==2.9.2
 python-dotenv==1.0.1
 python-jose[cryptography]==3.3.0
+SQLAlchemy==2.0.34
+passlib[bcrypt]==1.7.4

--- a/backend/security.py
+++ b/backend/security.py
@@ -1,0 +1,57 @@
+import base64
+import hashlib
+import os
+from functools import lru_cache
+from typing import Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+from passlib.context import CryptContext
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+@lru_cache(maxsize=1)
+def _get_fernet() -> Fernet:
+    key = os.getenv("DATA_ENCRYPTION_KEY")
+    if not key:
+        secret = os.getenv("JWT_SECRET", "dev-secret-key")
+        derived_key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode()).digest())
+        key = derived_key.decode()
+
+    if isinstance(key, str):
+        key_bytes = key.encode()
+    else:
+        key_bytes = key
+
+    try:
+        return Fernet(key_bytes)
+    except ValueError as exc:
+        raise RuntimeError("Invalid DATA_ENCRYPTION_KEY. It must be 32 url-safe base64-encoded bytes.") from exc
+
+
+def encrypt_value(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    fernet = _get_fernet()
+    token = fernet.encrypt(value.encode())
+    return token.decode()
+
+
+def decrypt_value(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    fernet = _get_fernet()
+    try:
+        decrypted = fernet.decrypt(value.encode())
+    except InvalidToken as exc:
+        raise RuntimeError("Unable to decrypt stored data. Check encryption key consistency.") from exc
+    return decrypted.decode()


### PR DESCRIPTION
## Summary
- introduce a SQLAlchemy-powered database layer with user and contact preference tables
- switch authentication flows to use persistent storage with hashed passwords and encrypted sensitive fields

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d818d9b25c8332971fed95873e6761