### PR TITLE
Handle CORS preflight requests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 from dotenv import load_dotenv
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
@@ -72,6 +73,14 @@ from backend.schemas import (
 load_dotenv()
 
 app = FastAPI(title="AI Act Compliance Manager API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret-key")
 JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")


### PR DESCRIPTION
## Summary
- add FastAPI CORS middleware so the API can respond to OPTIONS preflight requests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d852eb40808332af2ebd0e29dff4be