### PR TITLE
Add Docker Compose configuration for PostgreSQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,5 @@ SMTP_PASSWORD=contraseña
 SMTP_SENDER=no-reply@tu-dominio.com  # si lo omites usa SMTP_USERNAME
 SMTP_USE_TLS=true        # StartTLS (por defecto true)
 SMTP_USE_SSL=false       # SSL directo (por defecto false)
+# Base de datos (PostgreSQL en Docker Compose)
+DATABASE_URL=postgresql+psycopg://ai_act:ai_act@localhost:5432/ai_act_compliance

--- a/README.md
+++ b/README.md
@@ -166,6 +166,44 @@ flowchart LR
 
 ---
 
+## 🛠️ Base de datos PostgreSQL con Docker
+
+Si prefieres usar PostgreSQL en lugar del fichero SQLite incluido por defecto, puedes levantar la base de datos con Docker Compose:
+
+1. **Arranca el contenedor**
+
+   ```bash
+   docker compose up -d postgres
+   ```
+
+   El servicio expone PostgreSQL en `localhost:5432` con la base `ai_act_compliance` y las credenciales `ai_act` / `ai_act`.
+
+2. **Configura la URL de conexión**
+
+   Crea (o actualiza) tu archivo `.env` tomando como referencia `.env.example` e incluye:
+
+   ```env
+   DATABASE_URL=postgresql+psycopg://ai_act:ai_act@localhost:5432/ai_act_compliance
+   ```
+
+   El backend detectará automáticamente esta variable y usará PostgreSQL en lugar de SQLite.
+
+3. **Instala el driver de PostgreSQL**
+
+   Tras actualizar las dependencias, asegúrate de instalar `psycopg[binary]` incluido en `backend/requirements.txt`:
+
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+
+4. **Verifica la conexión**
+
+   Una vez arranque el backend, las tablas se crearán automáticamente. Puedes conectarte desde tu host con:
+
+   ```bash
+   psql postgresql://ai_act:ai_act@localhost:5432/ai_act_compliance
+   ```
+
 ## 🛠️ Puesta en marcha del backend (FastAPI)
 
 Sigue estos pasos para levantar el servidor de desarrollo y acceder a la documentación interactiva de la API:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv==1.0.1
 python-jose[cryptography]==3.3.0
 SQLAlchemy==2.0.34
 passlib==1.7.4
+psycopg[binary]==3.2.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: ai-act-postgres
+    environment:
+      POSTGRES_DB: ai_act_compliance
+      POSTGRES_USER: ai_act
+      POSTGRES_PASSWORD: ai_act
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ai_act -d ai_act_compliance"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add a Docker Compose service to run PostgreSQL locally with persistent storage
- document how to configure the application to use the Dockerized PostgreSQL instance
- include the psycopg driver in backend dependencies and expose the DATABASE_URL in the environment example

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d85a52ab0c83328b6d767160a7886a