### PR TITLE
Fix psycopg dependency version

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,4 +5,4 @@ python-dotenv==1.0.1
 python-jose[cryptography]==3.3.0
 SQLAlchemy==2.0.34
 passlib==1.7.4
-psycopg[binary]==3.2.1
+psycopg[binary]==3.2.3


### PR DESCRIPTION
## Summary
- update the psycopg[binary] requirement to a published 3.2.3 release
- add the missing trailing newline in backend/requirements.txt

## Testing
- pip install -r backend/requirements.txt *(fails: tunnel connection failed: 403 Forbidden while downloading psycopg)*

------
https://chatgpt.com/codex/tasks/task_e_68d864374ab08332affd769c8e41444f