### PR TITLE
Ensure environment variables load before database initialization

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,8 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
+load_dotenv()
+
 from backend.database import SessionLocal, get_db, init_db
 from backend.services.email_service import send_registration_code_email, send_welcome_email
 from backend.repositories.pending_user_repository import (
@@ -69,8 +71,6 @@ from backend.schemas import (
     User,
     UserPreferences,
 )
-
-load_dotenv()
 
 app = FastAPI(title="AI Act Compliance Manager API", version="0.1.0")
 


### PR DESCRIPTION
## Summary
- move the `load_dotenv()` call in `backend/main.py` so that it executes before importing the database module
- ensure database initialization resolves environment variables such as `DATABASE_URL` prior to engine creation

## Testing
- not run (dependencies for PostgreSQL driver unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d86ff81b2083328788563f988ce4b3