### PR TITLE
Ensure timezone-aware timestamps in registration flow

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,7 +1,7 @@
-from datetime import datetime
-from uuid import uuid4
-
+from datetime import datetime, timezone
+from functools import partial
 from typing import Optional
+from uuid import uuid4
 
 from sqlalchemy import DateTime, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -11,6 +11,9 @@ from .database import Base
 
 def generate_uuid() -> str:
     return str(uuid4())
+
+
+utc_now = partial(datetime.now, timezone.utc)
 
 
 class UserModel(Base):
@@ -23,9 +26,11 @@ class UserModel(Base):
     avatar: Mapped[str | None] = mapped_column(String(512), nullable=True)
     password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
     preferences_language: Mapped[str | None] = mapped_column(String(50), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime(timezone=True), default=utc_now, onupdate=utc_now
     )
 
     contact: Mapped[Optional["ContactPreferenceModel"]] = relationship(
@@ -47,9 +52,11 @@ class ContactPreferenceModel(Base):
     value_encrypted: Mapped[str] = mapped_column(String(1024), nullable=False)
     workspace_encrypted: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     channel_encrypted: Mapped[str | None] = mapped_column(String(1024), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime(timezone=True), default=utc_now, onupdate=utc_now
     )
 
     user: Mapped[UserModel] = relationship("UserModel", back_populates="contact")
@@ -72,12 +79,12 @@ class PendingUserRegistrationModel(Base):
     preferences_language: Mapped[str | None] = mapped_column(String(50), nullable=True)
     verification_code: Mapped[str] = mapped_column(String(32), nullable=False)
     code_sent_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+        DateTime(timezone=True), default=utc_now, nullable=False
     )
     code_expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+        DateTime(timezone=True), default=utc_now, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
     )

--- a/backend/repositories/pending_user_repository.py
+++ b/backend/repositories/pending_user_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import uuid4
 
@@ -34,7 +34,7 @@ def upsert_pending_registration(
     db: Session, payload: SignInPayload, code: str, expires_at: datetime
 ) -> PendingUserRegistrationModel:
     existing = get_pending_registration_by_email(db, payload.email)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     contact = payload.contact
     encrypted_value = encrypt_value(contact.value) or ""
@@ -85,7 +85,7 @@ def refresh_verification_code(
     db: Session, pending: PendingUserRegistrationModel, code: str, expires_at: datetime
 ) -> PendingUserRegistrationModel:
     pending.verification_code = code
-    pending.code_sent_at = datetime.utcnow()
+    pending.code_sent_at = datetime.now(timezone.utc)
     pending.code_expires_at = expires_at
     db.add(pending)
     db.commit()


### PR DESCRIPTION
## Summary
- replace registration verification timestamp calculations with timezone-aware `datetime.now(timezone.utc)`
- persist pending registration timestamps using UTC-aware datetimes in the repository layer
- configure SQLAlchemy models to default to UTC-aware datetimes for timezone-enabled columns via a reusable partial

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8f75602088332adc1f9926fbe4866