### PR TITLE
Use in-memory token when restoring auth session

### DIFF
--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -119,6 +119,14 @@ export function resendSignInCode(payload: SignInVerificationResendPayload) {
   })
 }
 
-export function fetchCurrentUser() {
-  return api<User>(PROFILE_ENDPOINT)
+export function fetchCurrentUser(token?: string) {
+  const init = token
+    ? {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      }
+    : undefined
+
+  return api<User>(PROFILE_ENDPOINT, init)
 }

--- a/frontend/src/shared/auth-context.tsx
+++ b/frontend/src/shared/auth-context.tsx
@@ -55,7 +55,7 @@ export function AuthProvider({ children }: React.PropsWithChildren) {
       setIsRestoringSession(true)
     }
 
-    fetchCurrentUser()
+    fetchCurrentUser(token)
       .then(profile => {
         if (cancelled) return
         setUser(profile)


### PR DESCRIPTION
## Summary
- allow `fetchCurrentUser` to accept an optional token and forward it as a bearer header
- update the auth context to use the in-memory token when restoring the current user session

## Testing
- not run (manual auth flow verification requires running the full application, which is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8fcfe1f788332ab095b9c9a87935b