### PR TITLE
Allow API token override for early auth fetch

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -16,14 +16,16 @@ function resolveUrl(path: string) {
   return `${BASE_URL}${normalizedPath}`
 }
 
-export async function api<T>(path: string, init?: RequestInit): Promise<T> {
-  const token = getStoredToken()
+export async function api<T>(path: string, init?: RequestInit, authToken?: string): Promise<T> {
+  const storedToken = getStoredToken()
   const headers = new Headers(init?.headers ?? {})
   if (!headers.has('Content-Type')) {
     headers.set('Content-Type', 'application/json')
   }
-  if (token && !headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${token}`)
+  if (authToken) {
+    headers.set('Authorization', `Bearer ${authToken}`)
+  } else if (storedToken && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${storedToken}`)
   }
 
   const response = await fetch(resolveUrl(path), {

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -120,13 +120,5 @@ export function resendSignInCode(payload: SignInVerificationResendPayload) {
 }
 
 export function fetchCurrentUser(token?: string) {
-  const init = token
-    ? {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      }
-    : undefined
-
-  return api<User>(PROFILE_ENDPOINT, init)
+  return api<User>(PROFILE_ENDPOINT, undefined, token)
 }

--- a/frontend/src/shared/auth-context.tsx
+++ b/frontend/src/shared/auth-context.tsx
@@ -55,7 +55,9 @@ export function AuthProvider({ children }: React.PropsWithChildren) {
       setIsRestoringSession(true)
     }
 
-    fetchCurrentUser(token)
+    const activeToken = token
+
+    fetchCurrentUser(activeToken)
       .then(profile => {
         if (cancelled) return
         setUser(profile)


### PR DESCRIPTION
## Summary
- add an optional token override to the shared api helper so callers can supply a bearer token explicitly
- update fetchCurrentUser to forward the latest JWT to the api helper instead of crafting headers manually
- ensure AuthProvider passes the in-memory token when restoring the session so the first /auth/me request is authenticated

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d915e45c108332a96e340120d5f48e