### PR TITLE
Persist auth state immediately after login

### DIFF
--- a/frontend/src/shared/auth-context.tsx
+++ b/frontend/src/shared/auth-context.tsx
@@ -104,6 +104,7 @@ export function AuthProvider({ children }: React.PropsWithChildren) {
         const response = await login(payload)
         setToken(response.token)
         setUser(response.user)
+        storeAuthState({ token: response.token, user: response.user })
         return response
       }),
     [runAuthAction]
@@ -115,6 +116,7 @@ export function AuthProvider({ children }: React.PropsWithChildren) {
         const response = await loginWithSSO(payload)
         setToken(response.token)
         setUser(response.user)
+        storeAuthState({ token: response.token, user: response.user })
         return response
       }),
     [runAuthAction]
@@ -132,6 +134,7 @@ export function AuthProvider({ children }: React.PropsWithChildren) {
         const response = await verifySignIn(payload)
         setToken(response.token)
         setUser(response.user)
+        storeAuthState({ token: response.token, user: response.user })
         return response
       }),
     [runAuthAction]


### PR DESCRIPTION
## Summary
- persist authentication data to local storage immediately after successful password, SSO, or registration verification flows
- ensure subsequent requests can access the stored token without waiting for the effect-driven persistence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d91b4678c88332b56e11c5eb4a5f7e