### PR TITLE
Refine auth storage test window stub

### DIFF
--- a/frontend/src/shared/auth-storage.test.ts
+++ b/frontend/src/shared/auth-storage.test.ts
@@ -22,9 +22,12 @@ describe('auth storage helpers', () => {
       })
     }
 
-    ;(globalThis as unknown as { window: Window }).window = {
+    const windowStub: Pick<Window, 'localStorage'> & Partial<typeof globalThis> = {
       localStorage
-    } as Window
+    }
+
+    vi.stubGlobal('window', windowStub)
+    vi.stubGlobal('localStorage', localStorage)
 
     clearStoredAuth()
   })


### PR DESCRIPTION
## Summary
- replace the manual window assignment in the auth storage tests with a vi.stubGlobal helper
- expose the mocked localStorage through both window and the global for existing expectations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9834da3c883329bd07ddc06099a99