### PR TITLE
Enable experimental decorators in frontend TypeScript config

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,6 +12,7 @@
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "experimentalDecorators": true,
     "noEmit": true,
     "jsx": "preserve",
     "types": [


### PR DESCRIPTION
## Summary
- enable TypeScript experimental decorators so Lit property decorators compile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a8bd36dc8332bd9036126d2f9c70