### PR TITLE
Fix router parameter typing and align context generics

### DIFF
--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -1,5 +1,6 @@
 import { Router } from '@lit-labs/router';
-import { html, type ReactiveElement } from 'lit';
+import type { ReactiveElement } from '@lit/reactive-element';
+import { html } from 'lit';
 import { authStore } from './state/auth-store';
 import { registerRouter } from './navigation';
 
@@ -21,7 +22,7 @@ function renderWithShell(content: unknown) {
   return html`<app-shell>${content}</app-shell>`;
 }
 
-type RouteParams = Record<string, string | undefined>;
+type RouteParams = Record<string, string>;
 
 export function createAppRouter(host: ReactiveElement): Router {
   let router: Router;
@@ -67,38 +68,38 @@ export function createAppRouter(host: ReactiveElement): Router {
     {
       path: '/projects/:id/incidents',
       enter: ensureAuthenticated,
-      render: ({ params }: { params: RouteParams }) =>
-        renderWithShell(html`<incidents-page project-id=${params.id ?? ''}></incidents-page>`)
+      render: (params: RouteParams) =>
+        renderWithShell(html`<incidents-page project-id=${params.id}></incidents-page>`)
     },
     {
       path: '/projects/:id/deliverables',
       enter: ensureAuthenticated,
-      render: ({ params }: { params: RouteParams }) =>
-        renderWithShell(html`<deliverables-page project-id=${params.id ?? ''}></deliverables-page>`)
+      render: (params: RouteParams) =>
+        renderWithShell(html`<deliverables-page project-id=${params.id}></deliverables-page>`)
     },
     {
       path: '/projects/:id/calendar',
       enter: ensureAuthenticated,
-      render: ({ params }: { params: RouteParams }) =>
-        renderWithShell(html`<calendar-workflows-page project-id=${params.id ?? ''}></calendar-workflows-page>`)
+      render: (params: RouteParams) =>
+        renderWithShell(html`<calendar-workflows-page project-id=${params.id}></calendar-workflows-page>`)
     },
     {
       path: '/projects/:id/org',
       enter: ensureAuthenticated,
-      render: ({ params }: { params: RouteParams }) =>
-        renderWithShell(html`<org-roles-page project-id=${params.id ?? ''}></org-roles-page>`)
+      render: (params: RouteParams) =>
+        renderWithShell(html`<org-roles-page project-id=${params.id}></org-roles-page>`)
     },
     {
       path: '/projects/:id/audit',
       enter: ensureAuthenticated,
-      render: ({ params }: { params: RouteParams }) =>
-        renderWithShell(html`<audit-evidences-page project-id=${params.id ?? ''}></audit-evidences-page>`)
+      render: (params: RouteParams) =>
+        renderWithShell(html`<audit-evidences-page project-id=${params.id}></audit-evidences-page>`)
     },
     {
       path: '/systems/:id',
       enter: ensureAuthenticated,
-      render: ({ params }: { params: RouteParams }) =>
-        renderWithShell(html`<system-detail-page system-id=${params.id ?? ''}></system-detail-page>`)
+      render: (params: RouteParams) =>
+        renderWithShell(html`<system-detail-page system-id=${params.id}></system-detail-page>`)
     },
     {
       path: '/incidents',

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -2304,7 +2304,7 @@ i18n.on('languageChanged', (language) => {
   }
 })
 
-export const t: typeof i18n.t = (...args) => i18n.t(...args)
+export const t = i18n.t.bind(i18n) as typeof i18n.t
 
 export function changeLanguage(language: SupportedLanguage) {
   return i18n.changeLanguage(language)

--- a/frontend/src/state/context.ts
+++ b/frontend/src/state/context.ts
@@ -1,7 +1,6 @@
 import { createContext } from '@lit-labs/context';
-import type { ReactiveElement } from 'lit';
 import type { AuthStore } from './auth-store';
 import type { ProjectStore } from './project-store';
 
-export const authStoreContext = createContext<AuthStore, ReactiveElement>(Symbol.for('aacm/auth-store'));
-export const projectStoreContext = createContext<ProjectStore, ReactiveElement>(Symbol.for('aacm/project-store'));
+export const authStoreContext = createContext<AuthStore>(Symbol.for('aacm/auth-store'));
+export const projectStoreContext = createContext<ProjectStore>(Symbol.for('aacm/project-store'));

--- a/frontend/src/state/controllers.ts
+++ b/frontend/src/state/controllers.ts
@@ -1,6 +1,6 @@
 import { ContextConsumer, ContextProvider, type Context } from '@lit-labs/context';
 import type { ReactiveController } from 'lit';
-import type { ReactiveElement } from 'lit';
+import type { ReactiveElement } from '@lit/reactive-element';
 import { authStore, type AuthStore } from './auth-store';
 import { projectStore, type ProjectStore } from './project-store';
 import { authStoreContext, projectStoreContext } from './context';
@@ -18,9 +18,9 @@ class BaseStoreController<TStore> implements ReactiveController {
   protected readonly host: ReactiveElement;
   protected store: TStore;
   private unsubscribe: () => void = () => {};
-  private readonly contextConsumer?: ContextConsumer<TStore, ReactiveElement>;
+  private readonly contextConsumer?: ContextConsumer<unknown, ReactiveElement>;
 
-  constructor(host: ReactiveElement, options: { store: TStore; context?: Context<TStore, ReactiveElement> }) {
+  constructor(host: ReactiveElement, options: { store: TStore; context?: Context<ReactiveElement, TStore> }) {
     this.host = host;
     this.store = options.store;
 
@@ -30,7 +30,7 @@ class BaseStoreController<TStore> implements ReactiveController {
         subscribe: true,
         callback: (value) => {
           if (value) {
-            this.#attachStore(value);
+            this.#attachStore(value as TStore);
           }
         }
       });


### PR DESCRIPTION
## Summary
- update the Lit router setup to use the parameter signature expected by @lit-labs/router
- align store context helpers and controllers with the current @lit-labs/context typings
- bind the shared i18n helper to the i18n instance to satisfy the latest type definition

## Testing
- `npm run build` *(fails: missing local npm dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b8e825c083329740057c1c78484e