### PR TITLE
Fix router param typing and align lit context types

### DIFF
--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -1,5 +1,5 @@
 import { Router } from '@lit-labs/router';
-import type { ReactiveElement } from '@lit/reactive-element';
+import type { ReactiveElement } from 'lit';
 import { html } from 'lit';
 import { authStore } from './state/auth-store';
 import { registerRouter } from './navigation';
@@ -21,8 +21,6 @@ import './pages/Auth/sign-in-page';
 function renderWithShell(content: unknown) {
   return html`<app-shell>${content}</app-shell>`;
 }
-
-type RouteParams = Record<string, string>;
 
 export function createAppRouter(host: ReactiveElement): Router {
   let router: Router;
@@ -68,37 +66,37 @@ export function createAppRouter(host: ReactiveElement): Router {
     {
       path: '/projects/:id/incidents',
       enter: ensureAuthenticated,
-      render: (params: RouteParams) =>
+      render: (params) =>
         renderWithShell(html`<incidents-page project-id=${params.id}></incidents-page>`)
     },
     {
       path: '/projects/:id/deliverables',
       enter: ensureAuthenticated,
-      render: (params: RouteParams) =>
+      render: (params) =>
         renderWithShell(html`<deliverables-page project-id=${params.id}></deliverables-page>`)
     },
     {
       path: '/projects/:id/calendar',
       enter: ensureAuthenticated,
-      render: (params: RouteParams) =>
+      render: (params) =>
         renderWithShell(html`<calendar-workflows-page project-id=${params.id}></calendar-workflows-page>`)
     },
     {
       path: '/projects/:id/org',
       enter: ensureAuthenticated,
-      render: (params: RouteParams) =>
+      render: (params) =>
         renderWithShell(html`<org-roles-page project-id=${params.id}></org-roles-page>`)
     },
     {
       path: '/projects/:id/audit',
       enter: ensureAuthenticated,
-      render: (params: RouteParams) =>
+      render: (params) =>
         renderWithShell(html`<audit-evidences-page project-id=${params.id}></audit-evidences-page>`)
     },
     {
       path: '/systems/:id',
       enter: ensureAuthenticated,
-      render: (params: RouteParams) =>
+      render: (params) =>
         renderWithShell(html`<system-detail-page system-id=${params.id}></system-detail-page>`)
     },
     {

--- a/frontend/src/state/controllers.ts
+++ b/frontend/src/state/controllers.ts
@@ -1,6 +1,5 @@
 import { ContextConsumer, ContextProvider, type Context } from '@lit-labs/context';
-import type { ReactiveController } from 'lit';
-import type { ReactiveElement } from '@lit/reactive-element';
+import type { ReactiveController, ReactiveElement } from 'lit';
 import { authStore, type AuthStore } from './auth-store';
 import { projectStore, type ProjectStore } from './project-store';
 import { authStoreContext, projectStoreContext } from './context';
@@ -18,7 +17,7 @@ class BaseStoreController<TStore> implements ReactiveController {
   protected readonly host: ReactiveElement;
   protected store: TStore;
   private unsubscribe: () => void = () => {};
-  private readonly contextConsumer?: ContextConsumer<unknown, ReactiveElement>;
+  private readonly contextConsumer?: ContextConsumer<Context<ReactiveElement, TStore>, ReactiveElement>;
 
   constructor(host: ReactiveElement, options: { store: TStore; context?: Context<ReactiveElement, TStore> }) {
     this.host = host;


### PR DESCRIPTION
## Summary
- update route render callbacks to accept the params signature expected by @lit-labs/router
- align ReactiveElement imports and context consumer typings with the lit context API to avoid duplicate type declarations

## Testing
- npm run build *(fails: missing local vite/vitest type definitions in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ba5ef028833297489db655270f41