### PR TITLE
Fix Lit context types and provide auth context shim

### DIFF
--- a/frontend/src/shared/auth-context.tsx
+++ b/frontend/src/shared/auth-context.tsx
@@ -1,0 +1,15 @@
+/**
+ * Legacy re-exports for auth/project context utilities.
+ *
+ * The previous React-based implementation lived in this module and external
+ * consumers may still import from it. We now expose the Lit-based stores and
+ * controllers so the TypeScript compiler can resolve the module without
+ * pulling React in as a dependency.
+ */
+export {
+  AuthController,
+  AuthStoreProvider,
+  ProjectController,
+  ProjectStoreProvider
+} from '../state/controllers';
+export { authStoreContext, projectStoreContext } from '../state/context';

--- a/frontend/src/state/controllers.ts
+++ b/frontend/src/state/controllers.ts
@@ -1,5 +1,5 @@
 import { ContextConsumer, ContextProvider, type Context } from '@lit-labs/context';
-import type { ReactiveController, ReactiveElement } from 'lit';
+import type { ReactiveController, ReactiveElement } from '@lit/reactive-element';
 import { authStore, type AuthStore } from './auth-store';
 import { projectStore, type ProjectStore } from './project-store';
 import { authStoreContext, projectStoreContext } from './context';
@@ -17,9 +17,9 @@ class BaseStoreController<TStore> implements ReactiveController {
   protected readonly host: ReactiveElement;
   protected store: TStore;
   private unsubscribe: () => void = () => {};
-  private readonly contextConsumer?: ContextConsumer<Context<ReactiveElement, TStore>, ReactiveElement>;
+  private readonly contextConsumer?: ContextConsumer<unknown, ReactiveElement>;
 
-  constructor(host: ReactiveElement, options: { store: TStore; context?: Context<ReactiveElement, TStore> }) {
+  constructor(host: ReactiveElement, options: { store: TStore; context?: Context<TStore> }) {
     this.host = host;
     this.store = options.store;
 


### PR DESCRIPTION
## Summary
- align the store controllers with `@lit/reactive-element` so the context controllers share the same element type definitions
- add a lightweight `shared/auth-context.tsx` module that re-exports the Lit store utilities without pulling in React

## Testing
- not run (npm registry access is blocked in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9bb89e6d08332b5f10720282a7e74