### PR TITLE
Fix LitElement host typing and improve test storage stub

### DIFF
--- a/frontend/src/app-root.ts
+++ b/frontend/src/app-root.ts
@@ -5,11 +5,13 @@ import { AuthStoreProvider, ProjectStoreProvider } from './state/controllers';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly authProvider = new AuthStoreProvider(this);
   private readonly projectProvider = new ProjectStoreProvider(this);
   private readonly router = createAppRouter(this);
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/components/app-shell.ts
+++ b/frontend/src/components/app-shell.ts
@@ -13,12 +13,14 @@ const NAVIGATION_ITEMS = [
 
 @customElement('app-shell')
 export class AppShell extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly auth = new AuthController(this);
   private readonly projects = new ProjectController(this);
 
   @state() private mobileMenuOpen = false;
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/AuditEvidences/audit-evidences-page.ts
+++ b/frontend/src/pages/AuditEvidences/audit-evidences-page.ts
@@ -5,11 +5,13 @@ import { getAuditDocuments, summarizeEvidences } from './AuditEvidences.viewmode
 
 @customElement('audit-evidences-page')
 export class AuditEvidencesPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly projects = new ProjectController(this);
 
   @property({ type: String, attribute: 'project-id' }) projectId = '';
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/Auth/login-page.ts
+++ b/frontend/src/pages/Auth/login-page.ts
@@ -5,6 +5,8 @@ import { navigateTo } from '../../navigation';
 
 @customElement('login-page')
 export class LoginPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly auth = new AuthController(this);
 
   @state() private company = '';
@@ -12,7 +14,7 @@ export class LoginPage extends LitElement {
   @state() private password = '';
   @state() private error: string | null = null;
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/Auth/sign-in-page.ts
+++ b/frontend/src/pages/Auth/sign-in-page.ts
@@ -6,6 +6,8 @@ type ContactMethod = 'email' | 'sms' | 'whatsapp' | 'slack';
 
 @customElement('sign-in-page')
 export class SignInPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly auth = new AuthController(this);
 
   @state() private fullName = '';
@@ -17,7 +19,7 @@ export class SignInPage extends LitElement {
   @state() private language = 'es';
   @state() private feedback: string | null = null;
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/CalendarWorkflows/calendar-workflows-page.ts
+++ b/frontend/src/pages/CalendarWorkflows/calendar-workflows-page.ts
@@ -5,11 +5,13 @@ import { getTasksForProject } from './CalendarWorkflows.viewmodel';
 
 @customElement('calendar-workflows-page')
 export class CalendarWorkflowsPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly projects = new ProjectController(this);
 
   @property({ type: String, attribute: 'project-id' }) projectId = '';
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/Dashboard/dashboard-page.ts
+++ b/frontend/src/pages/Dashboard/dashboard-page.ts
@@ -17,9 +17,11 @@ const STATUS_COLOR_MAP: Record<string, string> = {
 
 @customElement('dashboard-page')
 export class DashboardPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly model = createDashboardViewModel();
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/Deliverables/deliverables-page.ts
+++ b/frontend/src/pages/Deliverables/deliverables-page.ts
@@ -6,6 +6,8 @@ import { DeliverablesViewModel } from './Deliverables.viewmodel';
 
 @customElement('deliverables-page')
 export class DeliverablesPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly projects = new ProjectController(this);
 
   @property({ type: String, attribute: 'project-id' }) projectId = '';
@@ -15,7 +17,7 @@ export class DeliverablesPage extends LitElement {
   @state() private assignee = '';
   @state() private dueDate = '';
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/Incidents/incidents-page.ts
+++ b/frontend/src/pages/Incidents/incidents-page.ts
@@ -6,6 +6,8 @@ import { ProjectController } from '../../state/controllers';
 
 @customElement('incidents-page')
 export class IncidentsPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly viewModel = new IncidentsViewModel();
   private readonly projects = new ProjectController(this);
   private unsubscribe: (() => void) | null = null;
@@ -15,7 +17,7 @@ export class IncidentsPage extends LitElement {
   @state() private incidents: IncidentRow[] = [];
   @state() private loading = false;
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/OrgRoles/org-roles-page.ts
+++ b/frontend/src/pages/OrgRoles/org-roles-page.ts
@@ -5,11 +5,13 @@ import { getProjectContacts } from './OrgRoles.viewmodel';
 
 @customElement('org-roles-page')
 export class OrgRolesPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly projects = new ProjectController(this);
 
   @property({ type: String, attribute: 'project-id' }) projectId = '';
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/Projects/projects-page.ts
+++ b/frontend/src/pages/Projects/projects-page.ts
@@ -14,11 +14,13 @@ import {
 
 @customElement('projects-page')
 export class ProjectsPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly projectsStore = new ProjectController(this);
 
   @state() private filter: ProjectFilter = {};
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/Projects/projects-wizard-page.ts
+++ b/frontend/src/pages/Projects/projects-wizard-page.ts
@@ -7,6 +7,8 @@ import { navigateTo } from '../../navigation';
 
 @customElement('projects-wizard-page')
 export class ProjectsWizardPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly projects = new ProjectController(this);
 
   @state() private step = 0;

--- a/frontend/src/pages/Settings/settings-page.ts
+++ b/frontend/src/pages/Settings/settings-page.ts
@@ -5,11 +5,13 @@ import { getNotificationSettings, type NotificationSetting } from './Settings.vi
 
 @customElement('settings-page')
 export class SettingsPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly auth = new AuthController(this);
 
   @state() private selected: Set<string> = new Set(['incidents', 'deliverables']);
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/pages/SystemDetail/system-detail-page.ts
+++ b/frontend/src/pages/SystemDetail/system-detail-page.ts
@@ -6,6 +6,8 @@ import { SystemDetailViewModel } from './SystemDetail.viewmodel';
 
 @customElement('system-detail-page')
 export class SystemDetailPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
   private readonly viewModel = new SystemDetailViewModel();
   private unsubscribe: (() => void) | null = null;
 
@@ -15,7 +17,7 @@ export class SystemDetailPage extends LitElement {
   @state() private system: AISystem | null = null;
   @state() private assessments: RiskAssessmentRow[] = [];
 
-  protected createRenderRoot() {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/frontend/src/shared/auth-storage.test.ts
+++ b/frontend/src/shared/auth-storage.test.ts
@@ -13,14 +13,21 @@ describe('auth storage helpers', () => {
   beforeEach(() => {
     const store = new Map<string, string>()
     const localStorage = {
-      getItem: vi.fn((key: string) => (store.has(key) ? store.get(key)! : null)),
-      setItem: vi.fn((key: string, value: string) => {
-        store.set(key, value)
+      get length() {
+        return store.size
+      },
+      clear: vi.fn(() => {
+        store.clear()
       }),
+      getItem: vi.fn((key: string) => (store.has(key) ? store.get(key)! : null)),
+      key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
       removeItem: vi.fn((key: string) => {
         store.delete(key)
+      }),
+      setItem: vi.fn((key: string, value: string) => {
+        store.set(key, value)
       })
-    }
+    } as Storage
 
     const windowStub: Pick<Window, 'localStorage'> & Partial<typeof globalThis> = {
       localStorage

--- a/frontend/src/state/controllers.ts
+++ b/frontend/src/state/controllers.ts
@@ -17,7 +17,7 @@ class BaseStoreController<TStore> implements ReactiveController {
   protected readonly host: ReactiveElement;
   protected store: TStore;
   private unsubscribe: () => void = () => {};
-  private readonly contextConsumer?: ContextConsumer<unknown, ReactiveElement>;
+  private readonly contextConsumer?: ContextConsumer<Context<TStore>, ReactiveElement>;
 
   constructor(host: ReactiveElement, options: { store: TStore; context?: Context<TStore> }) {
     this.host = host;


### PR DESCRIPTION
## Summary
- declare HTMLElement render roots across LitElement hosts so they can be consumed by reactive controllers
- tighten BaseStoreController context typing for @lit-labs/context consumers
- extend the auth storage test stub to fully implement the Storage interface

## Testing
- npm --prefix frontend run build *(fails: missing vite/vitest type packages in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da1ec86c6083328176d8e3a9e5095a