### PR TITLE
Align Lit context types for store controllers

### DIFF
--- a/frontend/src/state/controllers.ts
+++ b/frontend/src/state/controllers.ts
@@ -1,5 +1,5 @@
 import { ContextConsumer, ContextProvider, type Context } from '@lit-labs/context';
-import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import type { ReactiveController, ReactiveElement } from '@lit/reactive-element';
 import { authStore, type AuthStore } from './auth-store';
 import { projectStore, type ProjectStore } from './project-store';
 import { authStoreContext, projectStoreContext } from './context';
@@ -14,12 +14,12 @@ function combineSubscriptions(subscriptions: Array<() => void>): () => void {
 }
 
 class BaseStoreController<TStore> implements ReactiveController {
-  protected readonly host: ReactiveControllerHost;
+  protected readonly host: ReactiveElement;
   protected store: TStore;
   private unsubscribe: () => void = () => {};
-  private readonly contextConsumer?: ContextConsumer<Context<TStore>, ReactiveControllerHost>;
+  private readonly contextConsumer?: ContextConsumer<Context<unknown, ReactiveElement>, ReactiveElement>;
 
-  constructor(host: ReactiveControllerHost, options: { store: TStore; context?: Context<TStore> }) {
+  constructor(host: ReactiveElement, options: { store: TStore; context?: Context<unknown, ReactiveElement> }) {
     this.host = host;
     this.store = options.store;
 
@@ -65,7 +65,7 @@ class BaseStoreController<TStore> implements ReactiveController {
 }
 
 export class AuthController extends BaseStoreController<AuthStore> {
-  constructor(host: ReactiveControllerHost, store: AuthStore = authStore) {
+  constructor(host: ReactiveElement, store: AuthStore = authStore) {
     super(host, { store, context: authStoreContext });
   }
 
@@ -106,7 +106,7 @@ export class AuthController extends BaseStoreController<AuthStore> {
 }
 
 export class ProjectController extends BaseStoreController<ProjectStore> {
-  constructor(host: ReactiveControllerHost, store: ProjectStore = projectStore) {
+  constructor(host: ReactiveElement, store: ProjectStore = projectStore) {
     super(host, { store, context: projectStoreContext });
   }
 
@@ -147,13 +147,13 @@ export class ProjectController extends BaseStoreController<ProjectStore> {
 }
 
 export class AuthStoreProvider extends ContextProvider<typeof authStoreContext> {
-  constructor(host: ReactiveControllerHost, store: AuthStore = authStore) {
+  constructor(host: ReactiveElement, store: AuthStore = authStore) {
     super(host, { context: authStoreContext, initialValue: store });
   }
 }
 
 export class ProjectStoreProvider extends ContextProvider<typeof projectStoreContext> {
-  constructor(host: ReactiveControllerHost, store: ProjectStore = projectStore) {
+  constructor(host: ReactiveElement, store: ProjectStore = projectStore) {
     super(host, { context: projectStoreContext, initialValue: store });
   }
 }


### PR DESCRIPTION
## Summary
- import Lit reactive element types from the same module as the context utilities to avoid duplicate type definitions
- relax the base controller's context typing so context consumers accept the descriptors returned by createContext

## Testing
- npm run build (fails: missing dev dependency type definitions in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68da2904a43c8332a418c76dd3da0bfc