### PR TITLE
Add dedicated verification route for sign-in flow

### DIFF
--- a/frontend/src/pages/Auth/sign-in-page.ts
+++ b/frontend/src/pages/Auth/sign-in-page.ts
@@ -1,6 +1,7 @@
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { AuthController } from '../../state/controllers';
+import { navigateTo } from '../../navigation';
 
 type ContactMethod = 'email' | 'sms' | 'whatsapp' | 'slack';
 
@@ -35,96 +36,102 @@ export class SignInPage extends LitElement {
         contact: { method: this.contactMethod, value: this.contactValue },
         preferences: { language: this.language }
       });
-      this.feedback = `Registro iniciado. Código enviado (id: ${response.registration_id}).`;
+      navigateTo(`/sign-in/verify?registration_id=${encodeURIComponent(response.registration_id)}`);
     } catch (error) {
       console.error(error);
       this.feedback = 'No se pudo completar el registro. Inténtalo más tarde.';
     }
   }
 
+  private renderRegistrationForm() {
+    return html`
+      <form class="card-body space-y-4" @submit=${this.handleSubmit}>
+        <header class="space-y-1 text-center">
+          <h1 class="text-3xl font-bold">Crear cuenta</h1>
+          <p class="text-base-content/70">Configura tu organización y comienza a trabajar con la plataforma.</p>
+        </header>
+
+        ${this.feedback ? html`<div class="alert alert-info text-sm">${this.feedback}</div>` : null}
+
+        <div class="grid gap-4 md:grid-cols-2">
+          <label class="form-control">
+            <span class="label"><span class="label-text">Nombre completo</span></span>
+            <input class="input input-bordered" required .value=${this.fullName} @input=${(event: Event) => {
+              const input = event.currentTarget as HTMLInputElement;
+              this.fullName = input.value;
+            }}>
+          </label>
+          <label class="form-control">
+            <span class="label"><span class="label-text">Compañía</span></span>
+            <input class="input input-bordered" required .value=${this.company} @input=${(event: Event) => {
+              const input = event.currentTarget as HTMLInputElement;
+              this.company = input.value;
+            }}>
+          </label>
+          <label class="form-control">
+            <span class="label"><span class="label-text">Correo profesional</span></span>
+            <input class="input input-bordered" type="email" required .value=${this.email} @input=${(event: Event) => {
+              const input = event.currentTarget as HTMLInputElement;
+              this.email = input.value;
+            }}>
+          </label>
+          <label class="form-control">
+            <span class="label"><span class="label-text">Contraseña</span></span>
+            <input class="input input-bordered" type="password" required .value=${this.password} @input=${(event: Event) => {
+              const input = event.currentTarget as HTMLInputElement;
+              this.password = input.value;
+            }}>
+          </label>
+        </div>
+
+        <div class="grid gap-4 md:grid-cols-2">
+          <label class="form-control">
+            <span class="label"><span class="label-text">Método de contacto</span></span>
+            <select class="select select-bordered" .value=${this.contactMethod} @change=${(event: Event) => {
+              const select = event.currentTarget as HTMLSelectElement;
+              this.contactMethod = select.value as ContactMethod;
+            }}>
+              <option value="email">Correo</option>
+              <option value="sms">SMS</option>
+              <option value="whatsapp">WhatsApp</option>
+              <option value="slack">Slack</option>
+            </select>
+          </label>
+          <label class="form-control">
+            <span class="label"><span class="label-text">Detalle de contacto</span></span>
+            <input class="input input-bordered" required .value=${this.contactValue} @input=${(event: Event) => {
+              const input = event.currentTarget as HTMLInputElement;
+              this.contactValue = input.value;
+            }}>
+          </label>
+          <label class="form-control">
+            <span class="label"><span class="label-text">Idioma preferido</span></span>
+            <select class="select select-bordered" .value=${this.language} @change=${(event: Event) => {
+              const select = event.currentTarget as HTMLSelectElement;
+              this.language = select.value;
+            }}>
+              <option value="es">Español</option>
+              <option value="en">Inglés</option>
+            </select>
+          </label>
+        </div>
+
+        <button class="btn btn-primary" type="submit" ?disabled=${this.auth.isAuthenticating}>
+          Registrar organización
+        </button>
+
+        <p class="text-sm text-base-content/70 text-center">
+          ¿Ya tienes cuenta? <a class="link" href="/login">Inicia sesión</a>
+        </p>
+      </form>
+    `;
+  }
+
   protected render() {
     return html`
       <main class="min-h-screen flex items-center justify-center bg-base-200">
         <section class="card w-full max-w-2xl bg-base-100 shadow-xl">
-          <form class="card-body space-y-4" @submit=${this.handleSubmit}>
-            <header class="space-y-1 text-center">
-              <h1 class="text-3xl font-bold">Crear cuenta</h1>
-              <p class="text-base-content/70">Configura tu organización y comienza a trabajar con la plataforma.</p>
-            </header>
-
-            ${this.feedback ? html`<div class="alert alert-info text-sm">${this.feedback}</div>` : null}
-
-            <div class="grid gap-4 md:grid-cols-2">
-              <label class="form-control">
-                <span class="label"><span class="label-text">Nombre completo</span></span>
-                <input class="input input-bordered" required .value=${this.fullName} @input=${(event: Event) => {
-                  const input = event.currentTarget as HTMLInputElement;
-                  this.fullName = input.value;
-                }}>
-              </label>
-              <label class="form-control">
-                <span class="label"><span class="label-text">Compañía</span></span>
-                <input class="input input-bordered" required .value=${this.company} @input=${(event: Event) => {
-                  const input = event.currentTarget as HTMLInputElement;
-                  this.company = input.value;
-                }}>
-              </label>
-              <label class="form-control">
-                <span class="label"><span class="label-text">Correo profesional</span></span>
-                <input class="input input-bordered" type="email" required .value=${this.email} @input=${(event: Event) => {
-                  const input = event.currentTarget as HTMLInputElement;
-                  this.email = input.value;
-                }}>
-              </label>
-              <label class="form-control">
-                <span class="label"><span class="label-text">Contraseña</span></span>
-                <input class="input input-bordered" type="password" required .value=${this.password} @input=${(event: Event) => {
-                  const input = event.currentTarget as HTMLInputElement;
-                  this.password = input.value;
-                }}>
-              </label>
-            </div>
-
-            <div class="grid gap-4 md:grid-cols-2">
-              <label class="form-control">
-                <span class="label"><span class="label-text">Método de contacto</span></span>
-                <select class="select select-bordered" .value=${this.contactMethod} @change=${(event: Event) => {
-                  const select = event.currentTarget as HTMLSelectElement;
-                  this.contactMethod = select.value as ContactMethod;
-                }}>
-                  <option value="email">Correo</option>
-                  <option value="sms">SMS</option>
-                  <option value="whatsapp">WhatsApp</option>
-                  <option value="slack">Slack</option>
-                </select>
-              </label>
-              <label class="form-control">
-                <span class="label"><span class="label-text">Detalle de contacto</span></span>
-                <input class="input input-bordered" required .value=${this.contactValue} @input=${(event: Event) => {
-                  const input = event.currentTarget as HTMLInputElement;
-                  this.contactValue = input.value;
-                }}>
-              </label>
-              <label class="form-control">
-                <span class="label"><span class="label-text">Idioma preferido</span></span>
-                <select class="select select-bordered" .value=${this.language} @change=${(event: Event) => {
-                  const select = event.currentTarget as HTMLSelectElement;
-                  this.language = select.value;
-                }}>
-                  <option value="es">Español</option>
-                  <option value="en">Inglés</option>
-                </select>
-              </label>
-            </div>
-
-            <button class="btn btn-primary" type="submit" ?disabled=${this.auth.isAuthenticating}>
-              Registrar organización
-            </button>
-
-            <p class="text-sm text-base-content/70 text-center">
-              ¿Ya tienes cuenta? <a class="link" href="/login">Inicia sesión</a>
-            </p>
-          </form>
+          ${this.renderRegistrationForm()}
         </section>
       </main>
     `;

--- a/frontend/src/pages/Auth/sign-in-verify-page.ts
+++ b/frontend/src/pages/Auth/sign-in-verify-page.ts
@@ -1,0 +1,153 @@
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { navigateTo } from '../../navigation';
+import { AuthController } from '../../state/controllers';
+
+@customElement('sign-in-verify-page')
+export class SignInVerifyPage extends LitElement {
+  declare renderRoot: HTMLElement;
+
+  private readonly auth = new AuthController(this);
+
+  @state() private registrationId: string | null = null;
+  @state() private verificationCode = '';
+  @state() private feedback: string | null = null;
+  @state() private verificationError: string | null = null;
+
+  private readonly handleLocationChange = () => {
+    this.updateRegistrationIdFromLocation();
+  };
+
+  constructor() {
+    super();
+    this.updateRegistrationIdFromLocation();
+  }
+
+  protected createRenderRoot(): HTMLElement {
+    return this;
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    window.addEventListener('popstate', this.handleLocationChange);
+  }
+
+  disconnectedCallback(): void {
+    window.removeEventListener('popstate', this.handleLocationChange);
+    super.disconnectedCallback();
+  }
+
+  private updateRegistrationIdFromLocation(): void {
+    const params = new URLSearchParams(window.location.search);
+    const registrationId = params.get('registration_id');
+    this.registrationId = registrationId?.trim() ? registrationId.trim() : null;
+    if (!this.registrationId) {
+      this.feedback = 'No encontramos un registro pendiente. Inicia un nuevo registro para continuar.';
+    } else {
+      this.feedback = null;
+    }
+  }
+
+  private handleCodeInput(event: Event): void {
+    const input = event.currentTarget as HTMLInputElement;
+    const sanitized = input.value.replace(/[^a-zA-Z0-9]/g, '').slice(0, 8).toUpperCase();
+    this.verificationCode = sanitized;
+    input.value = sanitized;
+  }
+
+  private async handleVerificationSubmit(event: Event): Promise<void> {
+    event.preventDefault();
+    if (!this.registrationId) {
+      this.verificationError = 'No se encontró el registro. Vuelve a iniciar el proceso.';
+      return;
+    }
+
+    if (this.verificationCode.length !== 8) {
+      this.verificationError = 'Introduce los 8 caracteres del código enviado.';
+      return;
+    }
+
+    this.verificationError = null;
+    this.feedback = null;
+    try {
+      await this.auth.value.verifyRegistration({
+        registration_id: this.registrationId,
+        code: this.verificationCode
+      });
+      this.feedback = 'Autenticación completada. Redirigiendo a la plataforma...';
+      navigateTo('/', { replace: true });
+    } catch (error) {
+      console.error(error);
+      this.verificationError = 'El código no es válido. Verifica e inténtalo nuevamente.';
+    }
+  }
+
+  private renderMissingRegistrationMessage() {
+    return html`
+      <div class="card-body space-y-6">
+        <header class="space-y-1 text-center">
+          <h1 class="text-3xl font-bold">Verificación no disponible</h1>
+          <p class="text-base-content/70">
+            ${this.feedback}
+          </p>
+        </header>
+
+        <button class="btn btn-primary" type="button" @click=${() => navigateTo('/sign-in')}>
+          Volver al registro
+        </button>
+      </div>
+    `;
+  }
+
+  private renderVerificationForm() {
+    return html`
+      <form class="card-body space-y-4" @submit=${this.handleVerificationSubmit}>
+        <header class="space-y-1 text-center">
+          <h1 class="text-3xl font-bold">Verifica tu cuenta</h1>
+          <p class="text-base-content/70">
+            Introduce el código de 8 caracteres enviado por tu método de contacto.
+          </p>
+        </header>
+
+        ${this.feedback ? html`<div class="alert alert-info text-sm">${this.feedback}</div>` : null}
+        ${this.verificationError ? html`<div class="alert alert-error text-sm">${this.verificationError}</div>` : null}
+
+        <label class="form-control">
+          <span class="label"><span class="label-text">Código de verificación</span></span>
+          <input
+            class="input input-bordered text-center tracking-widest"
+            required
+            minlength="8"
+            maxlength="8"
+            pattern="[A-Za-z0-9]{8}"
+            placeholder="XXXXXXXX"
+            autocomplete="one-time-code"
+            .value=${this.verificationCode}
+            @input=${this.handleCodeInput}
+          >
+        </label>
+
+        <button class="btn btn-primary" type="submit" ?disabled=${this.auth.isAuthenticating || this.verificationCode.length !== 8}>
+          Verificar y acceder
+        </button>
+
+        <p class="text-sm text-base-content/70 text-center">
+          ¿Necesitas modificar tus datos?
+          <button class="link" type="button" @click=${() => navigateTo('/sign-in')}>
+            Editar registro
+          </button>
+        </p>
+      </form>
+    `;
+  }
+
+  protected render() {
+    return html`
+      <main class="min-h-screen flex items-center justify-center bg-base-200">
+        <section class="card w-full max-w-2xl bg-base-100 shadow-xl">
+          ${this.registrationId ? this.renderVerificationForm() : this.renderMissingRegistrationMessage()}
+        </section>
+      </main>
+    `;
+  }
+}

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -17,6 +17,7 @@ import './pages/SystemDetail/system-detail-page';
 import './pages/Settings/settings-page';
 import './pages/Auth/login-page';
 import './pages/Auth/sign-in-page';
+import './pages/Auth/sign-in-verify-page';
 
 function renderWithShell(content: unknown) {
   return html`<app-shell>${content}</app-shell>`;
@@ -47,6 +48,10 @@ export function createAppRouter(host: ReactiveElement): Router {
     {
       path: '/sign-in',
       render: () => html`<sign-in-page></sign-in-page>`
+    },
+    {
+      path: '/sign-in/verify',
+      render: () => html`<sign-in-verify-page></sign-in-verify-page>`
     },
     {
       path: '/',


### PR DESCRIPTION
## Summary
- redirect successful registrations to a dedicated `/sign-in/verify` route instead of rendering the verification form inline
- implement the verification page to read the registration id from the URL, sanitize the 8-character code, and handle submission or missing registrations
- register the new verification route with the application router so the flow loads correctly

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68da41746e908332bfa5ae2d3e491b05