### PR TITLE
Fix sign-in verification navigation and button state

### DIFF
--- a/frontend/src/pages/Auth/sign-in-page.ts
+++ b/frontend/src/pages/Auth/sign-in-page.ts
@@ -2,7 +2,6 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { navigateTo } from '../../navigation';
 import { AuthController } from '../../state/controllers';
-import { navigateTo } from '../../navigation';
 
 type ContactMethod = 'email' | 'sms' | 'whatsapp' | 'slack';
 
@@ -43,8 +42,11 @@ export class SignInPage extends LitElement {
         contact: { method: this.contactMethod, value: this.contactValue },
         preferences: { language: this.language }
       });
-      navigateTo(`/sign-in/verify?registration_id=${encodeURIComponent(response.registration_id)}`);
-
+      if (response.registration_id) {
+        navigateTo(`/sign-in/verify?registration_id=${encodeURIComponent(response.registration_id)}`);
+      } else {
+        this.feedback = 'No se pudo iniciar la verificación. Inténtalo nuevamente.';
+      }
     } catch (error) {
       console.error(error);
       this.feedback = 'No se pudo completar el registro. Inténtalo más tarde.';

--- a/frontend/src/pages/Auth/sign-in-verify-page.ts
+++ b/frontend/src/pages/Auth/sign-in-verify-page.ts
@@ -13,6 +13,7 @@ export class SignInVerifyPage extends LitElement {
   @state() private verificationCode = '';
   @state() private feedback: string | null = null;
   @state() private verificationError: string | null = null;
+  @state() private isVerifying = false;
 
   private readonly handleLocationChange = () => {
     this.updateRegistrationIdFromLocation();
@@ -69,6 +70,7 @@ export class SignInVerifyPage extends LitElement {
 
     this.verificationError = null;
     this.feedback = null;
+    this.isVerifying = true;
     try {
       await this.auth.value.verifyRegistration({
         registration_id: this.registrationId,
@@ -79,6 +81,8 @@ export class SignInVerifyPage extends LitElement {
     } catch (error) {
       console.error(error);
       this.verificationError = 'El código no es válido. Verifica e inténtalo nuevamente.';
+    } finally {
+      this.isVerifying = false;
     }
   }
 
@@ -127,7 +131,7 @@ export class SignInVerifyPage extends LitElement {
           >
         </label>
 
-        <button class="btn btn-primary" type="submit" ?disabled=${this.auth.isAuthenticating || this.verificationCode.length !== 8}>
+        <button class="btn btn-primary" type="submit" ?disabled=${this.isVerifying || this.verificationCode.length !== 8}>
           Verificar y acceder
         </button>
 


### PR DESCRIPTION
## Summary
- ensure the sign-in flow handles missing registration IDs and navigates to the verification step only when one is returned
- track verification progress locally so the "Verificar y acceder" button enables once the code has eight characters

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68da494926208332aaa0554bec6f3da3