### PR TITLE
Add contextual project navigation menu

### DIFF
--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -35,6 +35,9 @@ const resources = {
         settings: "Ajustes",
         projectGroup: "Proyecto: {{name}}",
         project: {
+          evidences: "Evidencias",
+          teams: "Equipos",
+          audits: "Auditorías",
           deliverables: "Entregables",
           calendar: "Calendario",
           org: "Org y Roles",
@@ -716,6 +719,9 @@ const resources = {
         settings: "Settings",
         projectGroup: "Project: {{name}}",
         project: {
+          evidences: "Evidence",
+          teams: "Teams",
+          audits: "Audits",
           deliverables: "Deliverables",
           calendar: "Calendar",
           org: "Org & Roles",
@@ -1246,6 +1252,9 @@ const resources = {
         settings: "Configuració",
         projectGroup: "Projecte: {{name}}",
         project: {
+          evidences: "Evidències",
+          teams: "Equips",
+          audits: "Auditories",
           deliverables: "Lliurables",
           calendar: "Calendari",
           org: "Org i Rols",
@@ -1776,6 +1785,9 @@ const resources = {
         settings: "Paramètres",
         projectGroup: "Projet: {{name}}",
         project: {
+          evidences: "Preuves",
+          teams: "Équipes",
+          audits: "Audits",
           deliverables: "Livrables",
           calendar: "Calendrier",
           org: "Org & Rôles",


### PR DESCRIPTION
## Summary
- add a contextual project navigation menu that appears when a project is active
- ensure project navigation items close the mobile menu after navigation
- provide translation keys for the new project navigation labels in all supported languages

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dae46449788332981aaf2319f123a2