### PR TITLE
Update dashboard KPIs and evidence metrics

### DIFF
--- a/frontend/src/pages/Dashboard/dashboard-page.ts
+++ b/frontend/src/pages/Dashboard/dashboard-page.ts
@@ -29,21 +29,20 @@ export class DashboardPage extends LitElement {
       <div class="grid gap-4 md:grid-cols-4">
         <div class="card bg-base-100 shadow">
           <div class="card-body">
-            <span class="text-xs uppercase text-base-content/60">Documentación vigente</span>
-            <span class="text-3xl font-semibold">${kpis.docVigentePct}%</span>
-            <progress class="progress progress-primary" value=${kpis.docVigentePct} max="100"></progress>
+            <span class="text-xs uppercase text-base-content/60">Sistemas Registrados</span>
+            <span class="text-3xl font-semibold">${kpis.registeredSystems}</span>
           </div>
         </div>
         <div class="card bg-base-100 shadow">
           <div class="card-body">
-            <span class="text-xs uppercase text-base-content/60">Sistemas de alto riesgo</span>
-            <span class="text-3xl font-semibold">${kpis.highRisk}</span>
+            <span class="text-xs uppercase text-base-content/60">Sistemas de Alto Riesgo</span>
+            <span class="text-3xl font-semibold">${kpis.highRiskSystems}</span>
           </div>
         </div>
         <div class="card bg-base-100 shadow">
           <div class="card-body">
-            <span class="text-xs uppercase text-base-content/60">Total de sistemas</span>
-            <span class="text-3xl font-semibold">${kpis.totalSystems}</span>
+            <span class="text-xs uppercase text-base-content/60">Evidencias Pendientes (esta semana)</span>
+            <span class="text-3xl font-semibold">${kpis.pendingEvidencesThisWeek}</span>
           </div>
         </div>
         <div class="card bg-base-100 shadow">

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -146,10 +146,10 @@ const resources = {
       },
       dashboard: {
         metrics: {
-          docValid: "DoC vigente",
-          highRisk: "Sistemas alto riesgo",
-          totalSystems: "Total sistemas",
-          tasksToday: "Tareas hoy",
+          registeredSystems: "Sistemas registrados",
+          highRiskSystems: "Sistemas de alto riesgo",
+          pendingEvidencesThisWeek: "Evidencias pendientes (esta semana)",
+          tasksToday: "Tareas para hoy",
           tasksPending_one: "{{count}} pendiente",
           tasksPending_other: "{{count}} pendientes"
         },
@@ -830,10 +830,10 @@ const resources = {
       },
       dashboard: {
         metrics: {
-          docValid: "Valid DoC",
-          highRisk: "High-risk systems",
-          totalSystems: "Total systems",
-          tasksToday: "Tasks today",
+          registeredSystems: "Registered systems",
+          highRiskSystems: "High-risk systems",
+          pendingEvidencesThisWeek: "Pending evidence (this week)",
+          tasksToday: "Tasks for today",
           tasksPending_one: "{{count}} pending task",
           tasksPending_other: "{{count}} pending tasks"
         },
@@ -1363,10 +1363,10 @@ const resources = {
       },
       dashboard: {
         metrics: {
-          docValid: "DoC vigent",
-          highRisk: "Sistemes d'alt risc",
-          totalSystems: "Total de sistemes",
-          tasksToday: "Tasques d'avui",
+          registeredSystems: "Sistemes registrats",
+          highRiskSystems: "Sistemes d'alt risc",
+          pendingEvidencesThisWeek: "Evidències pendents (aquesta setmana)",
+          tasksToday: "Tasques per avui",
           tasksPending_one: "{{count}} tasca pendent",
           tasksPending_other: "{{count}} tasques pendents"
         },
@@ -1896,10 +1896,10 @@ const resources = {
       },
       dashboard: {
         metrics: {
-          docValid: "DoC en vigueur",
-          highRisk: "Systèmes à haut risque",
-          totalSystems: "Total des systèmes",
-          tasksToday: "Tâches du jour",
+          registeredSystems: "Systèmes enregistrés",
+          highRiskSystems: "Systèmes à haut risque",
+          pendingEvidencesThisWeek: "Preuves en attente (cette semaine)",
+          tasksToday: "Tâches pour aujourd'hui",
           tasksPending_one: "{{count}} tâche en attente",
           tasksPending_other: "{{count}} tâches en attente"
         },


### PR DESCRIPTION
## Summary
- replace the dashboard KPI set to expose registered systems, high-risk systems, pending evidences this week, and tasks today
- add a helper that assembles mock evidence data and counts pending items due within the current week
- refresh dashboard KPI labels in the dashboard page and i18n resources to reflect the new metrics

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dae5c5217c8332bceb1e112617f944