### PR TITLE
Fix active navigation highlighting in app shell

### DIFF
--- a/frontend/src/components/app-shell.ts
+++ b/frontend/src/components/app-shell.ts
@@ -153,8 +153,8 @@ export class AppShell extends LocalizedElement {
         ${NAVIGATION_ITEMS.map((item) => html`
           <li>
             <a
-              class=${classMap({ 'active font-semibold': active === item.href })}
-              aria-current=${active === item.href ? 'page' : undefined}
+              class=${classMap({ 'active font-semibold': activePath === item.href })}
+              aria-current=${activePath === item.href ? 'page' : undefined}
               @click=${() => this.handleNavigate(item.href)}
             >
               ${t(item.labelKey)}
@@ -167,7 +167,7 @@ export class AppShell extends LocalizedElement {
             <nav class="menu px-4 pb-6 text-base-content/80">
               ${PROJECT_NAV_ITEMS.map((item) => {
                 const href = item.getHref(activeProject.id);
-                const isActive = active.startsWith(href);
+                const isActive = activePath.startsWith(href);
                 return html`
                   <li>
                     <a


### PR DESCRIPTION
## Summary
- replace references to the nonexistent `active` variable with `activePath` when building navigation links
- ensure project navigation correctly determines when an item is active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def7fa885083329bd50753ebbe6bac