### PR TITLE
Refine top bar layout and pending actions navigation

### DIFF
--- a/frontend/src/components/app-shell.ts
+++ b/frontend/src/components/app-shell.ts
@@ -185,6 +185,38 @@ export class AppShell extends LocalizedElement {
     this.activePath = getCurrentPath();
   };
 
+  private handlePendingActions() {
+    const scrollToPendingActions = () => {
+      const target = document.getElementById('pending-actions');
+      if (!target) {
+        return false;
+      }
+      target.scrollIntoView({ behavior: 'smooth' });
+      return true;
+    };
+
+    const ensureScroll = (remainingAttempts = 40) => {
+      if (remainingAttempts <= 0) {
+        return;
+      }
+
+      if (getCurrentPath() !== '/') {
+        window.setTimeout(() => ensureScroll(remainingAttempts - 1), 100);
+        return;
+      }
+
+      if (!scrollToPendingActions()) {
+        window.setTimeout(() => ensureScroll(remainingAttempts - 1), 100);
+      }
+    };
+
+    if (getCurrentPath() !== '/') {
+      navigateTo('/');
+    }
+
+    ensureScroll();
+  }
+
   private toggleMenu() {
     this.mobileMenuOpen = !this.mobileMenuOpen;
   }
@@ -232,6 +264,27 @@ export class AppShell extends LocalizedElement {
       this.language = selectedLanguage;
       changeLanguage(selectedLanguage);
     }
+  }
+
+  private getUserInitials(fullName: string | null | undefined, email: string | null | undefined) {
+    const nameSource = fullName?.trim();
+    if (nameSource) {
+      const parts = nameSource.split(/\s+/).filter(Boolean);
+      if (parts.length === 1) {
+        return parts[0].slice(0, 2).toUpperCase();
+      }
+      return `${parts[0][0] ?? ''}${parts[parts.length - 1][0] ?? ''}`.toUpperCase();
+    }
+
+    const emailSource = email?.trim();
+    if (emailSource) {
+      const firstLetter = emailSource.replace(/@.*/, '').charAt(0);
+      if (firstLetter) {
+        return firstLetter.toUpperCase();
+      }
+    }
+
+    return '?';
   }
 
   private renderNavigation(activeProject: AISystem | null) {
@@ -336,9 +389,21 @@ export class AppShell extends LocalizedElement {
                   <span class="text-xl leading-none">☰</span>
                 </button>
               </div>
-              <div class="flex items-center gap-3 flex-1 min-w-0">
-                
-                <div class="flex-1 flex justify-end lg:justify-center">
+              <div class="flex-1 min-w-0 flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-6">
+                <div class="min-w-0">
+                  <div class="flex items-center gap-2 min-w-0">
+                    <h1 class="text-lg font-semibold truncate">
+                      ${activeProject?.name ?? t('app.layout.defaultProjectTitle')}
+                    </h1>
+                    ${activeProject
+                      ? html`<span class="badge badge-outline">${t(`roles.${activeProject.role}` as const)}</span>`
+                      : null}
+                  </div>
+                  ${activeProject
+                    ? null
+                    : html`<p class="text-xs text-base-content/60">${t('app.layout.selectProjectHint')}</p>`}
+                </div>
+                <div class="flex-1 w-full flex justify-start lg:justify-center">
                   <label
                     class="input input-bordered input-sm flex items-center gap-2 w-full max-w-md"
                     aria-label=${t('app.searchAria')}
@@ -351,7 +416,7 @@ export class AppShell extends LocalizedElement {
                   </label>
                 </div>
               </div>
-              <div class="flex items-center gap-4">
+              <div class="flex items-center gap-4 flex-none">
                 <label class="form-control w-auto min-w-[8rem]">
                   <select
                     id=${languageSelectId}
@@ -369,19 +434,33 @@ export class AppShell extends LocalizedElement {
                     )}
                   </select>
                 </label>
-                <div class="text-right">
-                  <p class="text-sm font-semibold">${user?.full_name ?? t('app.guestUser')}</p>
-                  <p class="text-xs text-base-content/60">${user?.email ?? t('app.noSession')}</p>
+                <div class="dropdown dropdown-end">
+                  <label
+                    tabindex="0"
+                    class="btn btn-ghost btn-circle avatar"
+                    aria-label=${t('app.userMenu.openMenu')}
+                  >
+                    <div class="w-9 rounded-full bg-primary text-primary-content flex items-center justify-center font-semibold uppercase">
+                      ${this.getUserInitials(user?.full_name, user?.email)}
+                    </div>
+                  </label>
+                  <ul
+                    tabindex="0"
+                    class="mt-3 p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52"
+                  >
+                    <li>
+                      <button type="button" class="justify-between" @click=${this.handlePendingActions}>
+                        ${t('app.userMenu.pendingActions')}
+                      </button>
+                    </li>
+                    <li>
+                      <button type="button" class="justify-between" @click=${this.logout}>
+                        ${t('app.logout')}
+                      </button>
+                    </li>
+                  </ul>
                 </div>
-                <button class="btn btn-sm" @click=${this.logout}>${t('app.logout')}</button>
-                <span class="hidden md:inline text-base-content/40">│</span>
               </div>
-            </div>
-            <div class="border-t border-base-300 px-4 py-3 flex flex-col lg:flex-row lg:items-center gap-2">
-              <h1 class="text-xl font-semibold flex-1">${activeProject?.name ?? t('app.layout.defaultProjectTitle')}</h1>
-              ${activeProject
-                ? html`<span class="badge badge-outline">${t(`roles.${activeProject.role}` as const)}</span>`
-                : html`<span class="text-sm text-base-content/60">${t('app.layout.selectProjectHint')}</span>`}
             </div>
           </header>
 

--- a/frontend/src/pages/Dashboard/dashboard-page.ts
+++ b/frontend/src/pages/Dashboard/dashboard-page.ts
@@ -202,7 +202,7 @@ export class DashboardPage extends LocalizedElement {
   private renderPendingActions() {
     const items = this.model.pendingActions;
     return html`
-      <div class="card bg-base-100 shadow">
+      <section id="pending-actions" class="card bg-base-100 shadow">
         <div class="card-body space-y-4">
           <header>
             <h2 class="card-title">${t('dashboard.actions.title')}</h2>
@@ -250,7 +250,7 @@ export class DashboardPage extends LocalizedElement {
                 </div>
               `}
         </div>
-      </div>
+      </section>
     `;
   }
 

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -40,6 +40,10 @@ const resources = {
         guestUser: "Invitado",
         noSession: "Sin sesión",
         logout: "Cerrar sesión",
+        userMenu: {
+          pendingActions: "Mis acciones pendientes",
+          openMenu: "Abrir menú de usuario"
+        },
         footer: {
           online: "Estado de conexión: Conectado",
           offline: "Estado de conexión: Sin conexión",
@@ -842,6 +846,10 @@ const resources = {
         guestUser: "Guest",
         noSession: "No session",
         logout: "Sign out",
+        userMenu: {
+          pendingActions: "My pending actions",
+          openMenu: "Open user menu"
+        },
         footer: {
           online: "Connection status: Online",
           offline: "Connection status: Offline",
@@ -1508,6 +1516,10 @@ const resources = {
         guestUser: "Convidat",
         noSession: "Sense sessió",
         logout: "Tanca la sessió",
+        userMenu: {
+          pendingActions: "Les meves accions pendents",
+          openMenu: "Obre el menú d'usuari"
+        },
         footer: {
           online: "Estat de connexió: Connectat",
           offline: "Estat de connexió: Sense connexió",
@@ -2174,6 +2186,10 @@ const resources = {
         guestUser: "Invité",
         noSession: "Pas de session",
         logout: "Se déconnecter",
+        userMenu: {
+          pendingActions: "Mes actions en attente",
+          openMenu: "Ouvrir le menu utilisateur"
+        },
         footer: {
           online: "Statut de connexion : En ligne",
           offline: "Statut de connexion : Hors ligne",


### PR DESCRIPTION
## Summary
- Rebuilt the app shell header into a single responsive bar with project context, search, language picker, and a dropdown avatar menu.
- Added a pending-actions handler that routes to the dashboard and scrolls to the anchored card.
- Localized the new user menu labels for every supported language and anchored the pending actions section in the dashboard.

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0d8b8c81c8332be43dd395a34ab13