### PR TITLE
Refactor app shell layout into header and sidebar components

### DIFF
--- a/frontend/src/components/app-header.ts
+++ b/frontend/src/components/app-header.ts
@@ -1,0 +1,174 @@
+import { html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import type { AISystem } from '../domain/models';
+import type { SupportedLanguage } from '../shared/i18n';
+import { t } from '../shared/i18n';
+import { LocalizedElement } from '../shared/localized-element';
+
+const styles = css`
+  :host {
+    display: block;
+  }
+`;
+
+@customElement('app-header')
+export class AppHeader extends LocalizedElement {
+  static override styles = [styles];
+
+  @property({ attribute: false }) activeProject: AISystem | null = null;
+  @property({ type: String }) language: SupportedLanguage = 'en';
+  @property({ attribute: false }) supportedLanguages: ReadonlyArray<SupportedLanguage> = [];
+  @property({ type: String }) userFullName: string | null = null;
+  @property({ type: String }) userEmail: string | null = null;
+
+  private getUserInitials() {
+    const nameSource = this.userFullName?.trim();
+    if (nameSource) {
+      const parts = nameSource.split(/\s+/).filter(Boolean);
+      if (parts.length === 1) {
+        return parts[0]?.slice(0, 2).toUpperCase() ?? '?';
+      }
+      const first = parts[0]?.charAt(0) ?? '';
+      const last = parts[parts.length - 1]?.charAt(0) ?? '';
+      const initials = `${first}${last}`;
+      return initials ? initials.toUpperCase() : '?';
+    }
+
+    const emailSource = this.userEmail?.trim();
+    if (emailSource) {
+      const firstLetter = emailSource.replace(/@.*/, '').charAt(0);
+      if (firstLetter) {
+        return firstLetter.toUpperCase();
+      }
+    }
+
+    return '?';
+  }
+
+  private handleLanguageChange(event: Event) {
+    const select = event.currentTarget as HTMLSelectElement;
+    this.dispatchEvent(
+      new CustomEvent<SupportedLanguage>('language-change', {
+        detail: select.value as SupportedLanguage,
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private requestPendingActions() {
+    this.dispatchEvent(
+      new CustomEvent('pending-actions', { bubbles: true, composed: true })
+    );
+  }
+
+  private requestLogout() {
+    this.dispatchEvent(new CustomEvent('logout', { bubbles: true, composed: true }));
+  }
+
+  private toggleMenu() {
+    this.dispatchEvent(new CustomEvent('toggle-menu', { bubbles: true, composed: true }));
+  }
+
+  render() {
+    const activeProject = this.activeProject;
+    const languageSelectId = 'language-select';
+    const languages = this.supportedLanguages.length
+      ? this.supportedLanguages
+      : ([this.language] as ReadonlyArray<SupportedLanguage>);
+
+    return html`
+      <header class="bg-base-100 border-b border-base-300 sticky top-0 z-20">
+        <div class="navbar gap-4 px-4 py-2">
+          <div class="flex-none lg:hidden">
+            <button
+              class="btn btn-ghost btn-square btn-sm"
+              @click=${this.toggleMenu}
+              aria-label=${t('app.menuToggle')}
+            >
+              <span class="text-xl leading-none">☰</span>
+            </button>
+          </div>
+          <div class="flex-1 min-w-0 flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-6">
+            <div class="min-w-0">
+              <div class="flex items-center gap-2 min-w-0">
+                <h1 class="text-lg font-semibold truncate">
+                  ${activeProject?.name ?? t('app.layout.defaultProjectTitle')}
+                </h1>
+                ${activeProject
+                  ? html`<span class="badge badge-outline">${t(`roles.${activeProject.role}` as const)}</span>`
+                  : null}
+              </div>
+              ${activeProject
+                ? null
+                : html`<p class="text-xs text-base-content/60">${t('app.layout.selectProjectHint')}</p>`}
+            </div>
+            <div class="flex-1 w-full flex justify-start lg:justify-center">
+              <label
+                class="input input-bordered input-sm flex items-center gap-2 w-full max-w-md"
+                aria-label=${t('app.searchAria')}
+              >
+                <input
+                  class="grow bg-transparent outline-none"
+                  type="search"
+                  placeholder=${t('app.searchPlaceholder')}
+                />
+              </label>
+            </div>
+          </div>
+          <div class="flex items-center gap-4 flex-none">
+            <label class="form-control w-auto min-w-[8rem]">
+              <select
+                id=${languageSelectId}
+                class="select select-bordered select-sm"
+                aria-label=${t('app.languageSelectAria')}
+                .value=${this.language}
+                @change=${this.handleLanguageChange}
+              >
+                ${languages.map(
+                  (language) => html`<option value=${language}>
+                    ${t(`languages.${language}.full`)}
+                  </option>`
+                )}
+              </select>
+            </label>
+            <div class="dropdown dropdown-end">
+              <label
+                tabindex="0"
+                class="btn btn-ghost btn-circle avatar"
+                aria-label=${t('app.userMenu.openMenu')}
+              >
+                <div
+                  class="w-9 rounded-full bg-primary text-primary-content flex items-center justify-center font-semibold uppercase"
+                >
+                  ${this.getUserInitials()}
+                </div>
+              </label>
+              <ul
+                tabindex="0"
+                class="mt-3 p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52"
+              >
+                <li class="menu-title px-2">
+                  <span class="text-sm font-semibold">
+                    ${this.userFullName?.trim() || this.userEmail || t('app.guestUser')}
+                  </span>
+                </li>
+                <li>
+                  <button type="button" class="justify-between" @click=${this.requestPendingActions}>
+                    ${t('app.userMenu.pendingActions')}
+                  </button>
+                </li>
+                <li>
+                  <button type="button" class="justify-between" @click=${this.requestLogout}>
+                    ${t('app.logout')}
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </header>
+    `;
+  }
+}

--- a/frontend/src/components/app-shell.ts
+++ b/frontend/src/components/app-shell.ts
@@ -1,7 +1,5 @@
 import { html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
-import type { AISystem } from '../domain/models';
 import { AuthController, ProjectController } from '../state/controllers';
 import { getCurrentPath, navigateTo } from '../navigation';
 import {
@@ -13,157 +11,10 @@ import {
 } from '../shared/i18n';
 import styles from '../styles.css?inline';
 import { LocalizedElement } from '../shared/localized-element';
+import './app-header';
+import './app-sidebar';
 
 const APP_VERSION = import.meta.env.VITE_APP_VERSION ?? '0.1.0';
-
-const NAVIGATION_ITEMS: ReadonlyArray<{
-  labelKey: 'nav.dashboard' | 'nav.projects' | 'nav.incidents' | 'nav.settings';
-  href: string;
-  icon: ReturnType<typeof html>;
-}> = [
-  {
-    labelKey: 'nav.dashboard',
-    href: '/',
-    icon: html`<svg
-      class="w-5 h-5"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke-width="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75V21h15V9.75"
-      />
-    </svg>`
-  },
-  {
-    labelKey: 'nav.projects',
-    href: '/projects',
-    icon: html`<svg
-      class="w-5 h-5"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke-width="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M3 7.5A1.5 1.5 0 0 1 4.5 6h4.379a1.5 1.5 0 0 1 1.06.44l1.121 1.12a1.5 1.5 0 0 0 1.06.44H19.5A1.5 1.5 0 0 1 21 9.5v9A1.5 1.5 0 0 1 19.5 20h-15A1.5 1.5 0 0 1 3 18.5v-11Z"
-      />
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M3 13.5h18"
-      />
-    </svg>`
-  },
-  {
-    labelKey: 'nav.incidents',
-    href: '/incidents',
-    icon: html`<svg
-      class="w-5 h-5"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke-width="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M12 9v3.75m0 3v.008h.008V15.75H12Zm9.53 3.75-7.5-13.5a1.125 1.125 0 0 0-1.96 0l-7.5 13.5A1.125 1.125 0 0 0 5.625 21h12.75a1.125 1.125 0 0 0 1.155-1.5Z"
-      />
-    </svg>`
-  },
-  {
-    labelKey: 'nav.settings',
-    href: '/settings',
-    icon: html`<svg
-      class="w-5 h-5"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke-width="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M9.75 3a.75.75 0 0 1 .75-.75h3a.75.75 0 0 1 .75.75V4.5A.75.75 0 0 0 15 5.25h1.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 0 .75.75h1.5a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-.75.75H18a.75.75 0 0 0-.75.75v1.5a.75.75 0 0 1-.75.75H15a.75.75 0 0 0-.75.75V21a.75.75 0 0 1-.75.75h-3A.75.75 0 0 1 9.75 21v-1.5A.75.75 0 0 0 9 18.75H7.5a.75.75 0 0 1-.75-.75V16.5A.75.75 0 0 0 6 15.75H4.5a.75.75 0 0 1-.75-.75v-3a.75.75 0 0 1 .75-.75H6a.75.75 0 0 0 .75-.75V9a.75.75 0 0 1 .75-.75H9A.75.75 0 0 0 9.75 7.5Z"
-      />
-      <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-    </svg>`
-  }
-];
-
-const PROJECT_NAV_ITEMS = [
-  {
-    labelKey: 'nav.project.evidences',
-    getHref: (projectId: string) => `/projects/${projectId}/deliverables`,
-    icon: html`<svg
-      class="w-5 h-5"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke-width="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
-      />
-    </svg>`
-  },
-  {
-    labelKey: 'nav.project.teams',
-    getHref: (projectId: string) => `/projects/${projectId}/org`,
-    icon: html`<svg
-      class="w-5 h-5"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke-width="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z"
-      />
-    </svg>`
-  },
-  {
-    labelKey: 'nav.project.audits',
-    getHref: (projectId: string) => `/projects/${projectId}/audit`,
-    icon: html`<svg
-      class="w-5 h-5"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke-width="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0 1 18 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3 1.5 1.5 3-3.75"
-      />
-    </svg>`
-  }
-] as const;
 
 @customElement('app-shell')
 export class AppShell extends LocalizedElement {
@@ -217,9 +68,9 @@ export class AppShell extends LocalizedElement {
     ensureScroll();
   }
 
-  private toggleMenu() {
+  private readonly toggleMenu = () => {
     this.mobileMenuOpen = !this.mobileMenuOpen;
-  }
+  };
 
   private handleNavigate(href: string) {
     navigateTo(href);
@@ -227,9 +78,8 @@ export class AppShell extends LocalizedElement {
     this.syncActivePath();
   }
 
-  private handleProjectChange(event: Event) {
-    const select = event.currentTarget as HTMLSelectElement;
-    this.projects.value.setActiveProjectId(select.value || null);
+  private handleProjectChange(projectId: string | null) {
+    this.projects.value.setActiveProjectId(projectId);
   }
 
   private logout() {
@@ -257,223 +107,50 @@ export class AppShell extends LocalizedElement {
     this.language = language;
   }
 
-  private handleLanguageChange(event: Event) {
-    const select = event.currentTarget as HTMLSelectElement;
-    const selectedLanguage = select.value as SupportedLanguage;
-    if (supportedLanguages.includes(selectedLanguage)) {
-      this.language = selectedLanguage;
-      changeLanguage(selectedLanguage);
+  private handleLanguageChange(language: SupportedLanguage) {
+    if (supportedLanguages.includes(language)) {
+      this.language = language;
+      changeLanguage(language);
     }
-  }
-
-  private getUserInitials(fullName: string | null | undefined, email: string | null | undefined) {
-    const nameSource = fullName?.trim();
-    if (nameSource) {
-      const parts = nameSource.split(/\s+/).filter(Boolean);
-      if (parts.length === 1) {
-        return parts[0].slice(0, 2).toUpperCase();
-      }
-      return `${parts[0][0] ?? ''}${parts[parts.length - 1][0] ?? ''}`.toUpperCase();
-    }
-
-    const emailSource = email?.trim();
-    if (emailSource) {
-      const firstLetter = emailSource.replace(/@.*/, '').charAt(0);
-      if (firstLetter) {
-        return firstLetter.toUpperCase();
-      }
-    }
-
-    return '?';
-  }
-
-  private renderNavigation(activeProject: AISystem | null) {
-    const activePath = this.activePath;
-    return html`
-      <nav class="menu px-4 py-6 text-base-content/80">
-        ${NAVIGATION_ITEMS.map((item) => html`
-          <li>
-            <a
-              class=${classMap({ 'active font-semibold': activePath === item.href })}
-              aria-current=${activePath === item.href ? 'page' : undefined}
-              href=${item.href}
-              @click=${() => this.handleNavigate(item.href)}
-            >
-              <span class="flex items-center gap-3">
-                <span class="text-base-content/60">${item.icon}</span>
-                <span>${t(item.labelKey)}</span>
-              </span>
-            </a>
-          </li>
-        `)}
-      </nav>
-      ${activeProject
-        ? html`
-            <nav class="menu px-4 pb-6 text-base-content/80">
-              ${PROJECT_NAV_ITEMS.map((item) => {
-                const href = item.getHref(activeProject.id);
-                const isActive = activePath.startsWith(href);
-                return html`
-                  <li>
-                    <a
-                      class=${classMap({ 'active font-semibold': isActive })}
-                      aria-current=${isActive ? 'page' : undefined}
-                      href=${href}
-                      @click=${() => this.handleNavigate(href)}
-                    >
-                      <span class="flex items-center gap-3">
-                        <span class="text-base-content/60">${item.icon}</span>
-                        <span>${t(item.labelKey)}</span>
-                      </span>
-                    </a>
-                  </li>
-                `;
-              })}
-            </nav>
-          `
-        : null}
-    `;
-  }
-
-  private renderProjectSelectorMenuItems() {
-    const projects = this.projects.projects;
-    if (!projects.length) {
-      return html`<span class="text-sm text-base-content/70">${t('app.projectSelector.empty')}</span>`;
-    }
-    return html`
-      <label class="form-control w-full max-w-xs">
-        <span class="label">
-          <span class="label-text text-sm font-medium">${t('app.projectSelector.title')}</span>
-        </span>
-        <select class="select select-bordered select-sm" @change=${this.handleProjectChange}>
-          <option value="">${t('app.projectSelector.all')}</option>
-          ${projects.map((project) => html`
-            <option value=${project.id} ?selected=${project.id === this.projects.activeProjectId}>
-              ${project.name}
-            </option>
-          `)}
-        </select>
-      </label>
-    `;
   }
 
   protected render() {
     const user = this.auth.user;
     const activeProject = this.projects.activeProject;
-    const languageSelectId = 'language-select';
 
     return html`
       <div class="min-h-screen flex bg-base-200 text-base-content">
-        <aside
-          class=${classMap({
-            'w-72 bg-base-100 border-r border-base-300 flex flex-col fixed inset-y-0 z-30 transform transition-transform lg:static lg:translate-x-0': true,
-            '-translate-x-full lg:translate-x-0': !this.mobileMenuOpen,
-            'translate-x-0': this.mobileMenuOpen
-          })}
-        >
-          <div class="p-6 border-b border-base-300">
-            <span class="text-lg font-semibold">${t('app.shortTitle')}</span>
-            <p class="text-sm text-base-content/60">${t('app.sidebarSubtitle')}</p>
-          </div>
-          <div class="border-b border-base-300 px-6 py-4 space-y-3">
-            ${this.renderProjectSelectorMenuItems()}
-          </div>
-          <div class="flex-1 overflow-y-auto">${this.renderNavigation(activeProject)}</div>
-        </aside>
+        <app-sidebar
+          .mobileMenuOpen=${this.mobileMenuOpen}
+          .activeProject=${activeProject}
+          .projects=${this.projects.projects}
+          .activeProjectId=${this.projects.activeProjectId}
+          .activePath=${this.activePath}
+          @navigate=${(event: CustomEvent<string>) => this.handleNavigate(event.detail)}
+          @project-change=${(event: CustomEvent<string | null>) => this.handleProjectChange(event.detail)}
+        ></app-sidebar>
 
         <div class="flex-1 flex flex-col">
-          <header class="bg-base-100 border-b border-base-300 sticky top-0 z-20">
-            <div class="navbar gap-4 px-4 py-2">
-              <div class="flex-none lg:hidden">
-                <button class="btn btn-ghost btn-square btn-sm" @click=${this.toggleMenu} aria-label=${t('app.menuToggle')}>
-                  <span class="text-xl leading-none">☰</span>
-                </button>
-              </div>
-              <div class="flex-1 min-w-0 flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-6">
-                <div class="min-w-0">
-                  <div class="flex items-center gap-2 min-w-0">
-                    <h1 class="text-lg font-semibold truncate">
-                      ${activeProject?.name ?? t('app.layout.defaultProjectTitle')}
-                    </h1>
-                    ${activeProject
-                      ? html`<span class="badge badge-outline">${t(`roles.${activeProject.role}` as const)}</span>`
-                      : null}
-                  </div>
-                  ${activeProject
-                    ? null
-                    : html`<p class="text-xs text-base-content/60">${t('app.layout.selectProjectHint')}</p>`}
-                </div>
-                <div class="flex-1 w-full flex justify-start lg:justify-center">
-                  <label
-                    class="input input-bordered input-sm flex items-center gap-2 w-full max-w-md"
-                    aria-label=${t('app.searchAria')}
-                  >
-                    <input
-                      class="grow bg-transparent outline-none"
-                      type="search"
-                      placeholder=${t('app.searchPlaceholder')}
-                    />
-                  </label>
-                </div>
-              </div>
-              <div class="flex items-center gap-4 flex-none">
-                <label class="form-control w-auto min-w-[8rem]">
-                  <select
-                    id=${languageSelectId}
-                    class="select select-bordered select-sm"
-                    aria-label=${t('app.languageSelectAria')}
-                    .value=${this.language}
-                    @change=${this.handleLanguageChange}
-                  >
-                    ${supportedLanguages.map(
-                      (language) => html`
-                        <option value=${language}>
-                          ${t(`languages.${language}.full`)}
-                        </option>
-                      `
-                    )}
-                  </select>
-                </label>
-                <div class="dropdown dropdown-end">
-                  <label
-                    tabindex="0"
-                    class="btn btn-ghost btn-circle avatar"
-                    aria-label=${t('app.userMenu.openMenu')}
-                  >
-                    <div class="w-9 rounded-full bg-primary text-primary-content flex items-center justify-center font-semibold uppercase">
-                      ${this.getUserInitials(user?.full_name, user?.email)}
-                    </div>
-                  </label>
-                  <ul
-                    tabindex="0"
-                    class="mt-3 p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52"
-                  >
-                    <li class="menu-title px-2">
-                      <span class="text-sm font-semibold">
-                        ${user?.full_name?.trim() || user?.email || t('app.guestUser')}
-                      </span>
-                    </li>
-                    <li>
-                      <button type="button" class="justify-between" @click=${this.handlePendingActions}>
-                        ${t('app.userMenu.pendingActions')}
-                      </button>
-                    </li>
-                    <li>
-                      <button type="button" class="justify-between" @click=${this.logout}>
-                        ${t('app.logout')}
-                      </button>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </header>
+          <app-header
+            .activeProject=${activeProject}
+            .language=${this.language}
+            .supportedLanguages=${supportedLanguages}
+            .userFullName=${user?.full_name ?? null}
+            .userEmail=${user?.email ?? null}
+            @toggle-menu=${this.toggleMenu}
+            @language-change=${(event: CustomEvent<SupportedLanguage>) =>
+              this.handleLanguageChange(event.detail)}
+            @pending-actions=${() => this.handlePendingActions()}
+            @logout=${() => this.logout()}
+          ></app-header>
 
           <main class="flex-1 overflow-y-auto p-6">
             <slot></slot>
           </main>
 
-          <footer class="bg-base-100 border-t border-base-300 px-6 py-3 text-sm text-base-content/70 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <footer
+            class="bg-base-100 border-t border-base-300 px-6 py-3 text-sm text-base-content/70 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between"
+          >
             <span>
               ${this.isOnline ? t('app.footer.online') : t('app.footer.offline')}
             </span>

--- a/frontend/src/components/app-sidebar.ts
+++ b/frontend/src/components/app-sidebar.ts
@@ -1,0 +1,183 @@
+import { html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import type { AISystem } from '../domain/models';
+import { t } from '../shared/i18n';
+import { LocalizedElement } from '../shared/localized-element';
+import {
+  auditsIcon,
+  dashboardIcon,
+  evidencesIcon,
+  incidentsIcon,
+  projectsIcon,
+  settingsIcon,
+  teamsIcon
+} from '../shared/icons';
+
+const baseStyles = css`
+  :host {
+    display: contents;
+  }
+`;
+
+type NavigationItem = {
+  labelKey: 'nav.dashboard' | 'nav.projects' | 'nav.incidents' | 'nav.settings';
+  href: string;
+  icon: () => ReturnType<typeof dashboardIcon>;
+};
+
+type ProjectNavigationItem = {
+  labelKey: 'nav.project.evidences' | 'nav.project.teams' | 'nav.project.audits';
+  getHref: (projectId: string) => string;
+  icon: () => ReturnType<typeof dashboardIcon>;
+};
+
+const NAVIGATION_ITEMS: ReadonlyArray<NavigationItem> = [
+  { labelKey: 'nav.dashboard', href: '/', icon: dashboardIcon },
+  { labelKey: 'nav.projects', href: '/projects', icon: projectsIcon },
+  { labelKey: 'nav.incidents', href: '/incidents', icon: incidentsIcon },
+  { labelKey: 'nav.settings', href: '/settings', icon: settingsIcon }
+];
+
+const PROJECT_NAV_ITEMS: ReadonlyArray<ProjectNavigationItem> = [
+  {
+    labelKey: 'nav.project.evidences',
+    getHref: (projectId: string) => `/projects/${projectId}/deliverables`,
+    icon: evidencesIcon
+  },
+  {
+    labelKey: 'nav.project.teams',
+    getHref: (projectId: string) => `/projects/${projectId}/org`,
+    icon: teamsIcon
+  },
+  {
+    labelKey: 'nav.project.audits',
+    getHref: (projectId: string) => `/projects/${projectId}/audit`,
+    icon: auditsIcon
+  }
+];
+
+@customElement('app-sidebar')
+export class AppSidebar extends LocalizedElement {
+  static styles = [baseStyles];
+
+  @property({ type: Boolean }) mobileMenuOpen = false;
+  @property({ attribute: false }) activeProject: AISystem | null = null;
+  @property({ attribute: false }) projects: ReadonlyArray<AISystem> = [];
+  @property({ attribute: false }) activeProjectId: string | null = null;
+  @property({ type: String }) activePath = '/';
+
+  private handleNavigate(event: Event, href: string) {
+    event.preventDefault();
+    this.dispatchEvent(
+      new CustomEvent<string>('navigate', { detail: href, bubbles: true, composed: true })
+    );
+  }
+
+  private handleProjectChange(event: Event) {
+    const select = event.currentTarget as HTMLSelectElement;
+    this.dispatchEvent(
+      new CustomEvent<string | null>('project-change', {
+        detail: select.value || null,
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private renderNavigation(activeProject: AISystem | null) {
+    const activePath = this.activePath;
+    return html`
+      <nav class="menu px-4 py-6 text-base-content/80">
+        ${NAVIGATION_ITEMS.map(
+          (item) => html`
+            <li>
+              <a
+                class=${classMap({ 'active font-semibold': activePath === item.href })}
+                aria-current=${activePath === item.href ? 'page' : undefined}
+                href=${item.href}
+                @click=${(event: Event) => this.handleNavigate(event, item.href)}
+              >
+                <span class="flex items-center gap-3">
+                  <span class="text-base-content/60">${item.icon()}</span>
+                  <span>${t(item.labelKey)}</span>
+                </span>
+              </a>
+            </li>
+          `
+        )}
+      </nav>
+      ${activeProject
+        ? html`
+            <nav class="menu px-4 pb-6 text-base-content/80">
+              ${PROJECT_NAV_ITEMS.map((item) => {
+                const href = item.getHref(activeProject.id);
+                const isActive = activePath.startsWith(href);
+                return html`
+                  <li>
+                    <a
+                      class=${classMap({ 'active font-semibold': isActive })}
+                      aria-current=${isActive ? 'page' : undefined}
+                      href=${href}
+                      @click=${(event: Event) => this.handleNavigate(event, href)}
+                    >
+                      <span class="flex items-center gap-3">
+                        <span class="text-base-content/60">${item.icon()}</span>
+                        <span>${t(item.labelKey)}</span>
+                      </span>
+                    </a>
+                  </li>`;
+              })}
+            </nav>
+          `
+        : null}
+    `;
+  }
+
+  private renderProjectSelectorMenuItems() {
+    if (!this.projects.length) {
+      return html`<span class="text-sm text-base-content/70">${t('app.projectSelector.empty')}</span>`;
+    }
+
+    return html`
+      <label class="form-control w-full max-w-xs">
+        <span class="label">
+          <span class="label-text text-sm font-medium">${t('app.projectSelector.title')}</span>
+        </span>
+        <select class="select select-bordered select-sm" @change=${this.handleProjectChange}>
+          <option value="">${t('app.projectSelector.all')}</option>
+          ${this.projects.map(
+            (project) => html`<option value=${project.id} ?selected=${project.id === this.activeProjectId}>
+              ${project.name}
+            </option>`
+          )}
+        </select>
+      </label>
+    `;
+  }
+
+  render() {
+    const activeProject = this.activeProject;
+
+    return html`
+      <aside
+        class=${classMap({
+          'w-72 bg-base-100 border-r border-base-300 flex flex-col fixed inset-y-0 z-30 transform transition-transform lg:static lg:translate-x-0':
+            true,
+          '-translate-x-full lg:translate-x-0': !this.mobileMenuOpen,
+          'translate-x-0': this.mobileMenuOpen
+        })}
+      >
+        <div class="p-6 border-b border-base-300">
+          <span class="text-lg font-semibold">${t('app.shortTitle')}</span>
+          <p class="text-sm text-base-content/60">${t('app.sidebarSubtitle')}</p>
+        </div>
+        <div class="border-b border-base-300 px-6 py-4 space-y-3">
+          ${this.renderProjectSelectorMenuItems()}
+        </div>
+        <div class="flex-1 overflow-y-auto">${this.renderNavigation(activeProject)}</div>
+      </aside>
+    `;
+  }
+}

--- a/frontend/src/shared/icons.ts
+++ b/frontend/src/shared/icons.ts
@@ -1,0 +1,130 @@
+import { html } from 'lit';
+import type { TemplateResult } from 'lit';
+
+export function dashboardIcon(): TemplateResult {
+  return html`<svg
+    class="w-5 h-5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75V21h15V9.75"
+    />
+  </svg>`;
+}
+
+export function projectsIcon(): TemplateResult {
+  return html`<svg
+    class="w-5 h-5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M3 7.5A1.5 1.5 0 0 1 4.5 6h4.379a1.5 1.5 0 0 1 1.06.44l1.121 1.12a1.5 1.5 0 0 0 1.06.44H19.5A1.5 1.5 0 0 1 21 9.5v9A1.5 1.5 0 0 1 19.5 20h-15A1.5 1.5 0 0 1 3 18.5v-11Z"
+    />
+    <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.5h18" />
+  </svg>`;
+}
+
+export function incidentsIcon(): TemplateResult {
+  return html`<svg
+    class="w-5 h-5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M12 9v3.75m0 3v.008h.008V15.75H12Zm9.53 3.75-7.5-13.5a1.125 1.125 0 0 0-1.96 0l-7.5 13.5A1.125 1.125 0 0 0 5.625 21h12.75a1.125 1.125 0 0 0 1.155-1.5Z"
+    />
+  </svg>`;
+}
+
+export function settingsIcon(): TemplateResult {
+  return html`<svg
+    class="w-5 h-5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M9.75 3a.75.75 0 0 1 .75-.75h3a.75.75 0 0 1 .75.75V4.5A.75.75 0 0 0 15 5.25h1.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 0 .75.75h1.5a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-.75.75H18a.75.75 0 0 0-.75.75v1.5a.75.75 0 0 1-.75.75H15a.75.75 0 0 0-.75.75V21a.75.75 0 0 1-.75.75h-3A.75.75 0 0 1 9.75 21v-1.5A.75.75 0 0 0 9 18.75H7.5a.75.75 0 0 1-.75-.75V16.5A.75.75 0 0 0 6 15.75H4.5a.75.75 0 0 1-.75-.75v-3a.75.75 0 0 1 .75-.75H6a.75.75 0 0 0 .75-.75V9a.75.75 0 0 1 .75-.75H9A.75.75 0 0 0 9.75 7.5Z"
+    />
+    <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+  </svg>`;
+}
+
+export function evidencesIcon(): TemplateResult {
+  return html`<svg
+    class="w-5 h-5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+    />
+  </svg>`;
+}
+
+export function teamsIcon(): TemplateResult {
+  return html`<svg
+    class="w-5 h-5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z"
+    />
+  </svg>`;
+}
+
+export function auditsIcon(): TemplateResult {
+  return html`<svg
+    class="w-5 h-5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0 1 18 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3 1.5 1.5 3-3.75"
+    />
+  </svg>`;
+}


### PR DESCRIPTION
## Summary
- extract the header and sidebar portions of the app shell into dedicated Lit components
- move reusable navigation SVG icons into a shared module for use across components
- update the app shell to orchestrate the new components and handle their events

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0e19e8c3483329db33cc22c58d4ea