### PR TITLE
Fix header and sidebar styling with shared Tailwind CSS

### DIFF
--- a/frontend/src/components/app-header.ts
+++ b/frontend/src/components/app-header.ts
@@ -5,6 +5,7 @@ import type { AISystem } from '../domain/models';
 import type { SupportedLanguage } from '../shared/i18n';
 import { t } from '../shared/i18n';
 import { LocalizedElement } from '../shared/localized-element';
+import sharedStyles from '../styles.css?inline';
 
 const styles = css`
   :host {
@@ -14,7 +15,7 @@ const styles = css`
 
 @customElement('app-header')
 export class AppHeader extends LocalizedElement {
-  static override styles = [styles];
+  static override styles = [css([sharedStyles] as any), styles];
 
   @property({ attribute: false }) activeProject: AISystem | null = null;
   @property({ type: String }) language: SupportedLanguage = 'en';

--- a/frontend/src/components/app-sidebar.ts
+++ b/frontend/src/components/app-sidebar.ts
@@ -5,6 +5,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import type { AISystem } from '../domain/models';
 import { t } from '../shared/i18n';
 import { LocalizedElement } from '../shared/localized-element';
+import sharedStyles from '../styles.css?inline';
 import {
   auditsIcon,
   dashboardIcon,
@@ -60,7 +61,7 @@ const PROJECT_NAV_ITEMS: ReadonlyArray<ProjectNavigationItem> = [
 
 @customElement('app-sidebar')
 export class AppSidebar extends LocalizedElement {
-  static styles = [baseStyles];
+  static override styles = [css([sharedStyles] as any), baseStyles];
 
   @property({ type: Boolean }) mobileMenuOpen = false;
   @property({ attribute: false }) activeProject: AISystem | null = null;


### PR DESCRIPTION
## Summary
- include the global Tailwind/DaisyUI stylesheet in the header and sidebar components
- ensure their layout classes render correctly so desktop/mobile styling and icon sizes match expectations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0e4b5120083328eae5ccfd317f75f