### PR TITLE
refactor: reuse shared icons for dashboard metrics

### DIFF
--- a/frontend/src/pages/Dashboard/dashboard-page.ts
+++ b/frontend/src/pages/Dashboard/dashboard-page.ts
@@ -10,6 +10,7 @@ import {
 import styles from '../../styles.css?inline';
 import { LocalizedElement } from '../../shared/localized-element';
 import { t } from '../../shared/i18n';
+import { evidencesIcon, incidentsIcon, projectsIcon, tasksIcon } from '../../shared/icons';
 
 const STATUS_COLOR_MAP: Record<string, string> = {
   vigente: 'var(--su)',
@@ -72,79 +73,25 @@ export class DashboardPage extends LocalizedElement {
         label: t('dashboard.metrics.registeredProjects'),
         value: kpis.registeredSystems,
         subtitle: t('dashboard.metrics.registeredProjectsSubtitle'),
-        icon: html`<svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="h-5 w-5"
-        >
-          <path d="M4.75 6.75h6.5l1.5 2.5h6.5a1.5 1.5 0 0 1 1.5 1.5v7a1.5 1.5 0 0 1-1.5 1.5H4.75a1.5 1.5 0 0 1-1.5-1.5v-9a1.5 1.5 0 0 1 1.5-1.5Z" />
-          <path d="M12 12v4.5" />
-          <path d="M9.75 14.25h4.5" />
-        </svg>`
+        icon: projectsIcon()
       },
       {
         label: t('dashboard.metrics.highRiskProjects'),
         value: kpis.highRiskSystems,
         subtitle: t('dashboard.metrics.highRiskProjectsSubtitle'),
-        icon: html`<svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="h-5 w-5"
-        >
-          <path d="M3.75 18.75h16.5L12 3.75 3.75 18.75Z" />
-          <path d="M12 9.75v3.75" />
-          <circle cx="12" cy="16.5" r=".75" fill="currentColor" stroke="none" />
-        </svg>`
+        icon: incidentsIcon()
       },
       {
         label: t('dashboard.metrics.pendingEvidences'),
         value: kpis.pendingEvidencesThisWeek,
         subtitle: t('dashboard.metrics.pendingEvidencesSubtitle'),
-        icon: html`<svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="h-5 w-5"
-        >
-          <path d="M8.25 4.5h7.5a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5h-7.5a1.5 1.5 0 0 1-1.5-1.5v-12a1.5 1.5 0 0 1 1.5-1.5Z" />
-          <path d="M9.75 8.25h4.5" />
-          <path d="M9.75 11.25h4.5" />
-          <path d="M9.75 14.25h3" />
-        </svg>`
+        icon: evidencesIcon()
       },
       {
         label: t('dashboard.metrics.pendingTasks'),
         value: kpis.tasksToday,
         subtitle: t('dashboard.metrics.pendingTasksSubtitle'),
-        icon: html`<svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="h-5 w-5"
-        >
-          <rect x="4.5" y="5.25" width="15" height="13.5" rx="2" />
-          <path d="M9 9h6" />
-          <path d="M9 12h6" />
-          <path d="M9 15h3.75" />
-        </svg>`
+        icon: tasksIcon()
       }
     ];
 

--- a/frontend/src/shared/icons.ts
+++ b/frontend/src/shared/icons.ts
@@ -93,6 +93,23 @@ export function evidencesIcon(): TemplateResult {
   </svg>`;
 }
 
+export function tasksIcon(): TemplateResult {
+  return html`<svg
+    class="w-5 h-5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <rect x="4.5" y="5.25" width="15" height="13.5" rx="2" />
+    <path d="M9 9h6" />
+    <path d="M9 12h6" />
+    <path d="M9 15h3.75" />
+  </svg>`;
+}
+
 export function teamsIcon(): TemplateResult {
   return html`<svg
     class="w-5 h-5"


### PR DESCRIPTION
## Summary
- reuse shared icons from the shared icon library for dashboard KPI cards
- add a reusable tasks icon to the shared icon set

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0e5d39f4c83329de601b5cd171e4c