### PR TITLE
Implement dynamic risk wizard questionnaire

### DIFF
--- a/frontend/src/domain/models.ts
+++ b/frontend/src/domain/models.ts
@@ -46,6 +46,11 @@ export interface AISystem {
   docStatus?: DocStatus
   lastAssessment?: string // ISO date
   tags?: string[]
+  initialRiskAssessment?: {
+    classification: RiskLevel
+    justification: string
+    answers: RiskAnswer[]
+  }
 }
 
 export interface RiskAnswer {

--- a/frontend/src/pages/Projects/ProjectRiskWizard.viewmodel.ts
+++ b/frontend/src/pages/Projects/ProjectRiskWizard.viewmodel.ts
@@ -1,0 +1,179 @@
+import riskWizardConfig from '../../configs/risk-wizard.json';
+import type { RiskAnswer, RiskLevel } from '../../domain/models';
+
+export type RiskWizardQuestionType = 'boolean' | 'select' | 'multiselect' | 'text';
+
+export type RiskWizardQuestion = {
+  id: string;
+  text: string;
+  type: RiskWizardQuestionType;
+  options?: string[];
+  conditional?: {
+    on: unknown;
+    question: RiskWizardQuestion;
+  };
+};
+
+export type RiskWizardHelpLink = {
+  title: string;
+  url: string;
+};
+
+export type RiskWizardHelp = {
+  text: string;
+  links?: RiskWizardHelpLink[];
+};
+
+export type RiskWizardRuleConditionValue = 'not_empty' | string | string[];
+
+export type RiskWizardRule = {
+  if: Record<string, RiskWizardRuleConditionValue>;
+  classification: RiskLevel;
+  justification: string;
+};
+
+export type RiskWizardResult = {
+  classification: RiskLevel;
+  justification: string;
+};
+
+export type RiskWizardStep = {
+  id: string;
+  title: string;
+  help?: RiskWizardHelp;
+  questions?: RiskWizardQuestion[];
+  rules?: RiskWizardRule[];
+  default?: RiskWizardResult;
+};
+
+type RiskWizardState = {
+  stepIndex: number;
+  answers: Record<string, unknown>;
+  result: RiskWizardResult;
+};
+
+const wizardDefinition = riskWizardConfig.wizard;
+
+function isNonEmpty(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+  return Boolean(value);
+}
+
+export class ProjectRiskWizardViewModel {
+  readonly steps: RiskWizardStep[];
+  #state: RiskWizardState;
+  constructor() {
+    this.steps = wizardDefinition.steps as RiskWizardStep[];
+    this.#state = {
+      stepIndex: 0,
+      answers: {},
+      result: this.#evaluate()
+    };
+  }
+
+  get stepIndex(): number {
+    return this.#state.stepIndex;
+  }
+
+  get isOnFirstStep(): boolean {
+    return this.#state.stepIndex === 0;
+  }
+
+  get isComplete(): boolean {
+    return this.#state.stepIndex >= this.steps.length - 1;
+  }
+
+  get currentStep(): RiskWizardStep {
+    return this.steps[this.#state.stepIndex];
+  }
+
+  get answers(): Record<string, unknown> {
+    return { ...this.#state.answers };
+  }
+
+  get answersList(): RiskAnswer[] {
+    return Object.entries(this.#state.answers).map(([key, value]) => ({ key, value }));
+  }
+
+  get result(): RiskWizardResult {
+    return this.#state.result;
+  }
+
+  nextStep(): void {
+    if (this.#state.stepIndex >= this.steps.length - 1) {
+      return;
+    }
+    this.#state = {
+      ...this.#state,
+      stepIndex: this.#state.stepIndex + 1,
+      result: this.#evaluate()
+    };
+  }
+
+  previousStep(): void {
+    if (this.#state.stepIndex <= 0) {
+      return;
+    }
+    this.#state = {
+      ...this.#state,
+      stepIndex: this.#state.stepIndex - 1,
+      result: this.#evaluate()
+    };
+  }
+
+  setAnswer(questionId: string, value: unknown): void {
+    this.#state = {
+      ...this.#state,
+      answers: { ...this.#state.answers, [questionId]: value },
+      result: this.#evaluate({ ...this.#state.answers, [questionId]: value })
+    };
+  }
+
+  clearAnswer(questionId: string): void {
+    if (!(questionId in this.#state.answers)) return;
+    const { [questionId]: _removed, ...rest } = this.#state.answers;
+    this.#state = {
+      ...this.#state,
+      answers: rest,
+      result: this.#evaluate(rest)
+    };
+  }
+
+  #evaluate(answers: Record<string, unknown> = this.#state.answers): RiskWizardResult {
+    const resultStep = this.steps.find((step) => step.rules && step.default);
+    if (!resultStep || !resultStep.rules || !resultStep.default) {
+      return { classification: 'limitado', justification: '' };
+    }
+
+    for (const rule of resultStep.rules) {
+      if (this.#matchesRule(rule.if, answers)) {
+        return { classification: rule.classification, justification: rule.justification };
+      }
+    }
+
+    return resultStep.default;
+  }
+
+  #matchesRule(conditions: Record<string, RiskWizardRuleConditionValue>, answers: Record<string, unknown>): boolean {
+    return Object.entries(conditions).every(([questionId, expected]) => {
+      const answer = answers[questionId];
+      if (expected === 'not_empty') {
+        return isNonEmpty(answer);
+      }
+      if (Array.isArray(expected)) {
+        if (Array.isArray(answer)) {
+          return expected.some((value) => answer.includes(value));
+        }
+        return expected.includes(answer as string);
+      }
+      return answer === expected;
+    });
+  }
+}
+
+export type RiskWizardDefinition = typeof wizardDefinition;

--- a/frontend/src/pages/Projects/projects-wizard-page.ts
+++ b/frontend/src/pages/Projects/projects-wizard-page.ts
@@ -6,19 +6,29 @@ import type { Contact } from '../../domain/models';
 import { navigateTo } from '../../navigation';
 import { LocalizedElement } from '../../shared/localized-element';
 import { t } from '../../shared/i18n';
+import { infoCircleIcon } from '../../shared/icons';
+import {
+  ProjectRiskWizardViewModel,
+  type RiskWizardQuestion,
+  type RiskWizardResult,
+  type RiskWizardHelp
+} from './ProjectRiskWizard.viewmodel';
 
 @customElement('projects-wizard-page')
 export class ProjectsWizardPage extends LocalizedElement {
   declare renderRoot: HTMLElement;
 
   private readonly projects = new ProjectController(this);
+  private readonly riskWizard = new ProjectRiskWizardViewModel();
 
   @state() private step = 0;
   @state() private name = '';
   @state() private projectRole: AISystem['role'] = 'provider';
   @state() private businessUnit = '';
   @state() private team: Contact[] = [];
-  @state() private risk: AISystem['risk'] | undefined;
+  @state() private riskStepIndex = this.riskWizard.stepIndex;
+  @state() private riskResult: RiskWizardResult = this.riskWizard.result;
+  @state() private riskAnswers: Record<string, unknown> = this.riskWizard.answers;
   @state() private notes = '';
 
   protected createRenderRoot(): HTMLElement {
@@ -55,23 +65,49 @@ export class ProjectsWizardPage extends LocalizedElement {
   }
 
   private nextStep() {
+    if (this.step === 2 && !this.riskWizard.isComplete) {
+      this.riskWizard.nextStep();
+      this.updateRiskState();
+      return;
+    }
+
     if (this.step < this.steps.length - 1) {
       this.step += 1;
-    } else {
-      const project = this.projects.value.createProject({
-        name: this.name,
-        role: this.projectRole,
-        risk: this.risk,
-        team: this.team,
-        businessUnit: this.businessUnit
-      });
-      this.notes = '';
-      navigateTo(`/projects/${project.id}/deliverables`, { replace: true });
+      return;
     }
+
+    const result = this.riskResult;
+    const project = this.projects.value.createProject({
+      name: this.name,
+      role: this.projectRole,
+      team: this.team,
+      businessUnit: this.businessUnit,
+      risk: result?.classification,
+      riskAssessment: result
+        ? {
+            classification: result.classification,
+            justification: result.justification,
+            answers: this.riskWizard.answersList
+          }
+        : undefined
+    });
+    this.notes = '';
+    navigateTo(`/projects/${project.id}/deliverables`, { replace: true });
   }
 
   private prevStep() {
+    if (this.step === 2 && !this.riskWizard.isOnFirstStep) {
+      this.riskWizard.previousStep();
+      this.updateRiskState();
+      return;
+    }
     this.step = Math.max(0, this.step - 1);
+  }
+
+  private updateRiskState() {
+    this.riskStepIndex = this.riskWizard.stepIndex;
+    this.riskResult = this.riskWizard.result;
+    this.riskAnswers = this.riskWizard.answers;
   }
 
   private renderStepIndicator() {
@@ -170,37 +206,280 @@ export class ProjectsWizardPage extends LocalizedElement {
   }
 
   private renderRiskStep() {
+    const steps = this.riskWizard.steps;
+    const currentStep = this.riskWizard.currentStep;
+    const isResultStep = Boolean(currentStep.rules && currentStep.default);
+
     return html`
-      <div class="space-y-4">
-        <p class="text-sm text-base-content/70">${t('projects.wizard.risk.description')}</p>
-        <div class="join join-vertical md:join-horizontal">
-          ${(['alto', 'limitado', 'minimo'] as const).map((value) => html`
-            <button
-              class="btn join-item ${this.risk === value ? 'btn-primary' : 'btn-outline'}"
-              @click=${() => {
-                this.risk = value as AISystem['risk'];
+      <div class="space-y-6">
+        <div class="overflow-x-auto">
+          <ul class="steps steps-vertical md:steps-horizontal">
+            ${steps.map(
+              (step, index) => html`<li class="step ${index <= this.riskStepIndex ? 'step-primary' : ''}">${
+                step.title
+              }</li>`
+            )}
+          </ul>
+        </div>
+
+        <div class="space-y-4">
+          <div class="flex items-start gap-2">
+            <h2 class="text-xl font-semibold">${currentStep.title}</h2>
+            ${currentStep.help ? this.renderRiskStepHelp(currentStep.id, currentStep.help) : null}
+          </div>
+
+          ${currentStep.questions?.map((question) => this.renderRiskQuestion(question)) ?? null}
+
+          ${isResultStep ? this.renderRiskResult() : null}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderRiskStepHelp(stepId: string, help: RiskWizardHelp) {
+    const tooltipId = `risk-help-${stepId}`;
+    return html`
+      <div class="relative inline-flex group">
+        <button
+          type="button"
+          class="btn btn-circle btn-ghost btn-xs"
+          aria-label=${t('projects.wizard.help.ariaLabel')}
+          aria-describedby=${tooltipId}
+        >
+          ${infoCircleIcon()}
+        </button>
+        <div
+          id=${tooltipId}
+          role="tooltip"
+          class="pointer-events-none absolute right-0 top-full mt-2 w-72 max-w-sm rounded-md bg-base-200 p-4 text-sm shadow-lg opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
+        >
+          <p class="mb-2">${help.text}</p>
+          ${help.links && help.links.length
+            ? html`
+                <ul class="space-y-1">
+                  ${help.links.map(
+                    (link) => html`
+                      <li>
+                        <a class="link link-primary" href=${link.url} target="_blank" rel="noopener noreferrer">
+                          ${link.title}
+                        </a>
+                      </li>
+                    `
+                  )}
+                </ul>
+              `
+            : null}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderRiskQuestion(question: RiskWizardQuestion, nested = false): unknown {
+    const answer = this.riskAnswers[question.id];
+    const containerClass = nested ? 'mt-4' : '';
+
+    switch (question.type) {
+      case 'boolean':
+        return html`
+          <fieldset class="form-control ${containerClass}">
+            <legend class="label"><span class="label-text">${question.text}</span></legend>
+            <div class="flex flex-wrap gap-4">
+              <label class="label cursor-pointer gap-2">
+                <input
+                  class="radio radio-primary"
+                  type="radio"
+                  name=${question.id}
+                  value="true"
+                  .checked=${answer === true}
+                  @change=${() => this.handleBooleanAnswer(question, true)}
+                >
+                <span>${t('riskWizard.form.yes')}</span>
+              </label>
+              <label class="label cursor-pointer gap-2">
+                <input
+                  class="radio"
+                  type="radio"
+                  name=${question.id}
+                  value="false"
+                  .checked=${answer === false}
+                  @change=${() => this.handleBooleanAnswer(question, false)}
+                >
+                <span>${t('riskWizard.form.no')}</span>
+              </label>
+            </div>
+          </fieldset>
+          ${question.conditional && answer === question.conditional.on
+            ? html`<div class="mt-4 border-l border-base-300 pl-4">
+                ${this.renderRiskQuestion(question.conditional.question, true)}
+              </div>`
+            : null}
+        `;
+      case 'select':
+        return html`
+          <label class="form-control ${containerClass}">
+            <span class="label"><span class="label-text">${question.text}</span></span>
+            <select
+              class="select select-bordered"
+              .value=${typeof answer === 'string' ? answer : ''}
+              @change=${(event: Event) => {
+                const select = event.currentTarget as HTMLSelectElement;
+                this.handleSelectAnswer(question.id, select.value);
               }}
             >
-              ${t('projects.wizard.risk.option', {
-                risk: t(`riskLevels.${value}` as const)
+              <option value="">${t('riskWizard.form.selectPlaceholder')}</option>
+              ${(question.options ?? []).map(
+                (option) => html`<option value=${option}>${option}</option>`
+              )}
+            </select>
+          </label>
+        `;
+      case 'multiselect':
+        return html`
+          <fieldset class="form-control ${containerClass}">
+            <legend class="label"><span class="label-text">${question.text}</span></legend>
+            <div class="space-y-2">
+              ${(question.options ?? []).map((option) => {
+                const selected = Array.isArray(answer) ? (answer as unknown[]).includes(option) : false;
+                return html`
+                  <label class="label cursor-pointer justify-start gap-3">
+                    <input
+                      class="checkbox checkbox-sm"
+                      type="checkbox"
+                      .checked=${selected}
+                      @change=${(event: Event) => {
+                        const input = event.currentTarget as HTMLInputElement;
+                        this.handleMultiselectAnswer(question.id, option, input.checked);
+                      }}
+                    >
+                    <span>${option}</span>
+                  </label>
+                `;
               })}
-            </button>
-          `)}
-        </div>
-        <label class="form-control">
-          <span class="label"><span class="label-text">${t('projects.wizard.fields.notes')}</span></span>
-          <textarea
-            class="textarea textarea-bordered"
-            rows="4"
-            .value=${this.notes}
-            placeholder=${t('projects.wizard.placeholders.notes')}
-            @input=${(event: Event) => {
-              const textarea = event.currentTarget as HTMLTextAreaElement;
-              this.notes = textarea.value;
-            }}
-          ></textarea>
-        </label>
-      </div>
+            </div>
+          </fieldset>
+        `;
+      case 'text':
+      default:
+        return html`
+          <label class="form-control ${containerClass}">
+            <span class="label"><span class="label-text">${question.text}</span></span>
+            <textarea
+              class="textarea textarea-bordered"
+              rows="3"
+              .value=${typeof answer === 'string' ? (answer as string) : ''}
+              @input=${(event: Event) => {
+                const textarea = event.currentTarget as HTMLTextAreaElement;
+                this.handleTextAnswer(question.id, textarea.value);
+              }}
+            ></textarea>
+          </label>
+        `;
+    }
+  }
+
+  private handleBooleanAnswer(question: RiskWizardQuestion, value: boolean) {
+    this.riskWizard.setAnswer(question.id, value);
+    if (question.conditional && value !== question.conditional.on) {
+      this.riskWizard.clearAnswer(question.conditional.question.id);
+    }
+    this.updateRiskState();
+  }
+
+  private handleSelectAnswer(questionId: string, value: string) {
+    if (!value) {
+      this.riskWizard.clearAnswer(questionId);
+    } else {
+      this.riskWizard.setAnswer(questionId, value);
+    }
+    this.updateRiskState();
+  }
+
+  private handleMultiselectAnswer(questionId: string, option: string, checked: boolean) {
+    const current = Array.isArray(this.riskAnswers[questionId])
+      ? [...(this.riskAnswers[questionId] as string[])]
+      : [];
+    if (checked) {
+      if (!current.includes(option)) current.push(option);
+    } else {
+      const index = current.indexOf(option);
+      if (index >= 0) current.splice(index, 1);
+    }
+    if (current.length === 0) {
+      this.riskWizard.clearAnswer(questionId);
+    } else {
+      this.riskWizard.setAnswer(questionId, current);
+    }
+    this.updateRiskState();
+  }
+
+  private handleTextAnswer(questionId: string, value: string) {
+    if (!value.trim()) {
+      this.riskWizard.clearAnswer(questionId);
+    } else {
+      this.riskWizard.setAnswer(questionId, value);
+    }
+    this.updateRiskState();
+  }
+
+  private renderRiskResult() {
+    const result = this.riskResult;
+    const classificationLabel = t(`riskLevels.${result.classification}` as const);
+    const resultCopyKey = `riskWizard.results.${result.classification}` as const;
+    const implications = t(`${resultCopyKey}.implications` as const);
+    const nextSteps = t(`${resultCopyKey}.next_steps` as const, {
+      returnObjects: true
+    }) as string[];
+
+    return html`
+      <article class="rounded-lg border border-base-300 bg-base-200/40 p-4">
+        <h3 class="text-lg font-semibold">${t('riskWizard.result.title')}</h3>
+        <dl class="mt-3 space-y-2">
+          <div>
+            <dt class="text-sm font-medium text-base-content/70">
+              ${t('riskWizard.result.classificationLabel')}
+            </dt>
+            <dd class="text-base font-semibold capitalize">${classificationLabel}</dd>
+          </div>
+          <div>
+            <dt class="text-sm font-medium text-base-content/70">
+              ${t('riskWizard.result.justification')}
+            </dt>
+            <dd>${result.justification}</dd>
+          </div>
+        </dl>
+
+        ${implications
+          ? html`<p class="mt-4 text-sm">${t('riskWizard.result.implications')}</p>
+              <p class="text-sm text-base-content/80">${implications}</p>`
+          : null}
+
+        ${Array.isArray(nextSteps) && nextSteps.length
+          ? html`
+              <div class="mt-4">
+                <p class="text-sm font-medium text-base-content/70">
+                  ${t('riskWizard.result.nextSteps')}
+                </p>
+                <ul class="list-disc space-y-1 pl-5 text-sm">
+                  ${nextSteps.map((step) => html`<li>${step}</li>`)}
+                </ul>
+              </div>
+            `
+          : null}
+      </article>
+
+      <label class="form-control">
+        <span class="label"><span class="label-text">${t('projects.wizard.fields.notes')}</span></span>
+        <textarea
+          class="textarea textarea-bordered"
+          rows="4"
+          .value=${this.notes}
+          placeholder=${t('projects.wizard.placeholders.notes')}
+          @input=${(event: Event) => {
+            const textarea = event.currentTarget as HTMLTextAreaElement;
+            this.notes = textarea.value;
+          }}
+        ></textarea>
+      </label>
     `;
   }
 
@@ -215,7 +494,10 @@ export class ProjectsWizardPage extends LocalizedElement {
             this.businessUnit || t('projects.wizard.summary.unset')
           }</p>
           <p><strong>${t('projects.wizard.fields.risk')}:</strong> ${
-            this.risk ? t(`riskLevels.${this.risk}` as const) : t('projects.wizard.summary.unclassifiedRisk')
+            this.riskResult ? t(`riskLevels.${this.riskResult.classification}` as const) : t('projects.wizard.summary.unclassifiedRisk')
+          }</p>
+          <p><strong>${t('projects.wizard.summary.justification')}:</strong> ${
+            this.riskResult?.justification ?? t('projects.wizard.summary.unset')
           }</p>
           <p><strong>${t('projects.wizard.summary.contacts')}:</strong> ${t(
             'projects.wizard.summary.teamCount',
@@ -243,8 +525,7 @@ export class ProjectsWizardPage extends LocalizedElement {
   }
 
   protected render() {
-    const canContinue =
-      this.step === 0 ? this.name.trim().length > 0 : this.step === 2 ? Boolean(this.risk) : true;
+    const canContinue = this.step === 0 ? this.name.trim().length > 0 : true;
 
     return html`
       <section class="space-y-6">

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -515,6 +515,9 @@ const resources = {
             riskAssessment: "Evaluación de Riesgo",
             summary: "Resumen"
           },
+          help: {
+            ariaLabel: "Mostrar ayuda del paso"
+          },
           fields: {
             name: "Nombre del proyecto",
             role: "Rol en la cadena de valor",
@@ -551,6 +554,7 @@ const resources = {
             teamCount: "{{count}} contactos",
             unset: "No definida",
             unclassifiedRisk: "Sin clasificar",
+            justification: "Justificación",
             noNotes: "Sin notas"
           },
           finish: "Crear Proyecto"
@@ -1191,6 +1195,9 @@ const resources = {
             riskAssessment: "Risk Assessment",
             summary: "Summary"
           },
+          help: {
+            ariaLabel: "Show step help"
+          },
           fields: {
             name: "Project name",
             role: "Role in the value chain",
@@ -1227,6 +1234,7 @@ const resources = {
             teamCount: "{{count}} contacts",
             unset: "Not defined",
             unclassifiedRisk: "Unclassified",
+            justification: "Justification",
             noNotes: "No notes"
           },
           finish: "Create Project"
@@ -1867,6 +1875,9 @@ const resources = {
             riskAssessment: "Avaluació de Risc",
             summary: "Resum"
           },
+          help: {
+            ariaLabel: "Mostra l'ajuda del pas"
+          },
           fields: {
             name: "Nom del projecte",
             role: "Rol a la cadena de valor",
@@ -1903,6 +1914,7 @@ const resources = {
             teamCount: "{{count}} contactes",
             unset: "No definida",
             unclassifiedRisk: "Sense classificar",
+            justification: "Justificació",
             noNotes: "Sense notes"
           },
           finish: "Crea Projecte"
@@ -2543,6 +2555,9 @@ const resources = {
             riskAssessment: "Évaluation des Risques",
             summary: "Résumé"
           },
+          help: {
+            ariaLabel: "Afficher l'aide de l'étape"
+          },
           fields: {
             name: "Nom du projet",
             role: "Rôle dans la chaîne de valeur",
@@ -2579,6 +2594,7 @@ const resources = {
             teamCount: "{{count}} contacts",
             unset: "Non défini",
             unclassifiedRisk: "Non classé",
+            justification: "Justification",
             noNotes: "Aucune note"
           },
           finish: "Créer le Projet"

--- a/frontend/src/shared/icons.ts
+++ b/frontend/src/shared/icons.ts
@@ -128,6 +128,24 @@ export function teamsIcon(): TemplateResult {
   </svg>`;
 }
 
+export function infoCircleIcon(): TemplateResult {
+  return html`<svg
+    class="h-4 w-4"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M11.25 11.25h1.5v3m-0.75-8.25h.008v.008H11.25V6Zm9 6a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+    />
+  </svg>`;
+}
+
 export function auditsIcon(): TemplateResult {
   return html`<svg
     class="w-5 h-5"

--- a/frontend/src/state/project-store.ts
+++ b/frontend/src/state/project-store.ts
@@ -1,4 +1,4 @@
-import type { AISystem, Contact, DeliverableType, DocumentRef, Task } from '../domain/models';
+import type { AISystem, Contact, DeliverableType, DocumentRef, RiskAnswer, Task } from '../domain/models';
 import { systems as initialSystems } from '../mocks/data';
 import { ObservableValue } from './observable';
 
@@ -19,6 +19,11 @@ export type CreateProjectInput = {
   team?: Contact[];
   risk?: AISystem['risk'];
   businessUnit?: string;
+  riskAssessment?: {
+    classification: AISystem['risk'];
+    justification: string;
+    answers: RiskAnswer[];
+  };
 };
 
 function readStoredActiveProject(): string | null {
@@ -67,9 +72,16 @@ export class ProjectStore {
       role: input.role,
       businessUnit: input.businessUnit,
       team: input.team,
-      risk: input.risk,
+      risk: input.risk ?? input.riskAssessment?.classification,
       docStatus: 'borrador',
-      lastAssessment: now.toISOString().slice(0, 10)
+      lastAssessment: now.toISOString().slice(0, 10),
+      initialRiskAssessment: input.riskAssessment
+        ? {
+            classification: input.riskAssessment.classification,
+            justification: input.riskAssessment.justification,
+            answers: input.riskAssessment.answers.map((answer) => ({ ...answer }))
+          }
+        : undefined
     };
 
     this.projects.update((prev) => [...prev, newProject]);


### PR DESCRIPTION
## Summary
- introduce a dedicated ProjectRiskWizard view model to load the JSON questionnaire, manage internal steps and evaluate result rules
- rebuild the projects wizard risk step to render questions dynamically with contextual help, result details and notes tied to the new model
- persist the computed classification and answers when creating projects and update locale resources/icons to support the new UI affordances

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0ee33dae08332a7f80bdea5492069