### PR TITLE
Add LocalStorage draft persistence to new project wizard

### DIFF
--- a/frontend/src/pages/Projects/ProjectRiskWizard.viewmodel.ts
+++ b/frontend/src/pages/Projects/ProjectRiskWizard.viewmodel.ts
@@ -69,10 +69,12 @@ export class ProjectRiskWizardViewModel {
   #state: RiskWizardState;
   constructor() {
     this.steps = wizardDefinition.steps as RiskWizardStep[];
+    const answers: Record<string, unknown> = {};
+    const result = this.#evaluate(answers);
     this.#state = {
       stepIndex: 0,
-      answers: {},
-      result: this.#evaluate()
+      answers,
+      result
     };
   }
 

--- a/frontend/src/shared/events/types.ts
+++ b/frontend/src/shared/events/types.ts
@@ -9,3 +9,5 @@ export type AppEvent =
   | { type: 'DOCUMENT_UPDATED', payload: { document: DocumentRef } }
   | { type: 'EVIDENCE_ADDED', payload: { evidence: Evidence } }
   | { type: 'TASKS_CHANGED', payload: { systemId?: UUID } }
+  | { type: 'PROJECT_DRAFT_UPDATED', payload: { tempId: string; storageKey: string } }
+  | { type: 'PROJECT_DRAFT_CLEARED', payload: { tempId: string; storageKey: string } }


### PR DESCRIPTION
## Summary
- add a temporary project id and LocalStorage draft persistence for the wizard, autosaving step data and notifying the sync agent
- restore saved drafts on connect, add cancel handling, and clear/reset drafts when finishing or cancelling the flow
- expose draft-related events and guard the risk wizard viewmodel so it can be reinstantiated safely during draft restoration

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0f60efd648332b9c0f8ce731284f0