### PR TITLE
Reset active project for new wizard and improve risk indicators

### DIFF
--- a/frontend/src/pages/Projects/projects-wizard.viewmodel.ts
+++ b/frontend/src/pages/Projects/projects-wizard.viewmodel.ts
@@ -82,6 +82,7 @@ export class ProjectsWizardViewModel implements ReactiveController {
   }
 
   hostConnected(): void {
+    this.#projects.value.setActiveProjectId(null);
     this.#ensureTempProjectId();
     this.#restoreDraft();
   }

--- a/frontend/src/pages/Projects/team-member-form.ts
+++ b/frontend/src/pages/Projects/team-member-form.ts
@@ -44,6 +44,8 @@ export class TeamMemberForm extends LocalizedElement {
     };
     this.isOwner = false;
     this.isReviewer = false;
+    const form = this.renderRoot.querySelector('form');
+    form?.reset();
   }
 
   private handleSubmit(event: Event) {


### PR DESCRIPTION
## Summary
- clear the active project when opening the new project wizard so the created project becomes the active selection
- reset the team member form inputs after adding a member in the wizard
- color-code risk results, update summary output, and raise help tooltip z-index so information buttons appear above the drawer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1125c6c88833293553f119ccc9ed1