### PR TITLE
Sync project store with routed project id

### DIFF
--- a/frontend/src/pages/AuditEvidences/audit-evidences-page.ts
+++ b/frontend/src/pages/AuditEvidences/audit-evidences-page.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ProjectController } from '../../state/controllers';
 import { getAuditDocuments, summarizeEvidences } from './AuditEvidences.viewmodel';
@@ -25,6 +25,22 @@ export class AuditEvidencesPage extends LocalizedElement {
 
   protected createRenderRoot(): HTMLElement {
     return this;
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
+    if (!changedProperties.has('projectId')) {
+      return;
+    }
+
+    const newProjectId = this.projectId?.trim();
+    if (newProjectId) {
+      if (this.projects.activeProjectId !== newProjectId) {
+        this.projects.value.setActiveProjectId(newProjectId);
+      }
+    } else if (this.projects.activeProjectId !== null) {
+      this.projects.value.setActiveProjectId(null);
+    }
   }
 
   protected render() {

--- a/frontend/src/pages/CalendarWorkflows/calendar-workflows-page.ts
+++ b/frontend/src/pages/CalendarWorkflows/calendar-workflows-page.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ProjectController } from '../../state/controllers';
 import { getTasksForProject } from './CalendarWorkflows.viewmodel';
@@ -15,6 +15,22 @@ export class CalendarWorkflowsPage extends LocalizedElement {
 
   protected createRenderRoot(): HTMLElement {
     return this;
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
+    if (!changedProperties.has('projectId')) {
+      return;
+    }
+
+    const newProjectId = this.projectId?.trim();
+    if (newProjectId) {
+      if (this.projects.activeProjectId !== newProjectId) {
+        this.projects.value.setActiveProjectId(newProjectId);
+      }
+    } else if (this.projects.activeProjectId !== null) {
+      this.projects.value.setActiveProjectId(null);
+    }
   }
 
   protected render() {

--- a/frontend/src/pages/Deliverables/deliverables-page.ts
+++ b/frontend/src/pages/Deliverables/deliverables-page.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ProjectController } from '../../state/controllers';
 import type { DocumentRef } from '../../domain/models';
@@ -29,6 +29,22 @@ export class DeliverablesPage extends LocalizedElement {
 
   private get viewModel() {
     return new DeliverablesViewModel(this.projects.value);
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
+    if (!changedProperties.has('projectId')) {
+      return;
+    }
+
+    const newProjectId = this.projectId?.trim();
+    if (newProjectId) {
+      if (this.projects.activeProjectId !== newProjectId) {
+        this.projects.value.setActiveProjectId(newProjectId);
+      }
+    } else if (this.projects.activeProjectId !== null) {
+      this.projects.value.setActiveProjectId(null);
+    }
   }
 
   private translateStatus(status: DocumentRef['status']): string {

--- a/frontend/src/pages/Incidents/incidents-page.ts
+++ b/frontend/src/pages/Incidents/incidents-page.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { IncidentRow } from './Service/incidents.service';
 import { IncidentsViewModel } from './Incidents.viewmodel';
@@ -44,9 +44,19 @@ export class IncidentsPage extends LocalizedElement {
     super.disconnectedCallback();
   }
 
-  protected updated(changed: Map<string, unknown>): void {
-    if (changed.has('projectId')) {
-      this.requestUpdate();
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
+    if (!changedProperties.has('projectId')) {
+      return;
+    }
+
+    const newProjectId = this.projectId?.trim();
+    if (newProjectId) {
+      if (this.projects.activeProjectId !== newProjectId) {
+        this.projects.value.setActiveProjectId(newProjectId);
+      }
+    } else if (this.projects.activeProjectId !== null) {
+      this.projects.value.setActiveProjectId(null);
     }
   }
 

--- a/frontend/src/pages/OrgRoles/org-roles-page.ts
+++ b/frontend/src/pages/OrgRoles/org-roles-page.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ProjectController } from '../../state/controllers';
 import { getProjectContacts } from './OrgRoles.viewmodel';
@@ -14,6 +14,22 @@ export class OrgRolesPage extends LocalizedElement {
 
   protected createRenderRoot(): HTMLElement {
     return this;
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
+    if (!changedProperties.has('projectId')) {
+      return;
+    }
+
+    const newProjectId = this.projectId?.trim();
+    if (newProjectId) {
+      if (this.projects.activeProjectId !== newProjectId) {
+        this.projects.value.setActiveProjectId(newProjectId);
+      }
+    } else if (this.projects.activeProjectId !== null) {
+      this.projects.value.setActiveProjectId(null);
+    }
   }
 
   protected render() {


### PR DESCRIPTION
## Summary
- ensure deliverables, incidents, calendar workflows, org roles, and audit evidences pages sync the routed project id with the project store
- clear the active project when a route omits the project id so the shell returns to the unscoped state

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1485ad2a483329146c7c7b665443f