### PR TITLE
Update project selector placeholder handling

### DIFF
--- a/frontend/src/components/app-sidebar.ts
+++ b/frontend/src/components/app-sidebar.ts
@@ -141,13 +141,21 @@ export class AppSidebar extends LocalizedElement {
       return html`<span class="text-sm text-base-content/70">${t('app.projectSelector.empty')}</span>`;
     }
 
+    const emptyOptionLabel = this.activeProjectId
+      ? t('app.projectSelector.all')
+      : t('app.projectSelector.placeholder');
+
     return html`
       <label class="form-control w-full max-w-xs">
         <span class="label">
           <span class="label-text text-sm font-medium">${t('app.projectSelector.title')}</span>
         </span>
-        <select class="select select-bordered select-sm" @change=${this.handleProjectChange}>
-          <option value="">${t('app.projectSelector.all')}</option>
+        <select
+          class="select select-bordered select-sm"
+          @change=${this.handleProjectChange}
+          .value=${this.activeProjectId ?? ''}
+        >
+          <option value="">${emptyOptionLabel}</option>
           ${this.projects.map(
             (project) => html`<option value=${project.id} ?selected=${project.id === this.activeProjectId}>
               ${project.name}

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -30,6 +30,7 @@ const resources = {
         menuToggle: "Abrir menú",
         projectSelector: {
           title: "Proyecto activo",
+          placeholder: "Seleccionar Proyecto",
           all: "Todos los proyectos",
           empty: "Sin proyectos activos"
         },
@@ -904,6 +905,7 @@ const resources = {
         menuToggle: "Open menu",
         projectSelector: {
           title: "Active project",
+          placeholder: "Select project",
           all: "All projects",
           empty: "No active projects"
         },
@@ -1642,6 +1644,7 @@ const resources = {
         menuToggle: "Obrir menú",
         projectSelector: {
           title: "Projecte actiu",
+          placeholder: "Seleccionar projecte",
           all: "Tots els projectes",
           empty: "Sense projectes actius"
         },
@@ -2380,6 +2383,7 @@ const resources = {
         menuToggle: "Ouvrir le menu",
         projectSelector: {
           title: "Projet actif",
+          placeholder: "Sélectionner un projet",
           all: "Tous les projets",
           empty: "Aucun projet actif"
         },


### PR DESCRIPTION
## Summary
- add explicit project selector placeholder translations across locales
- show the placeholder label when no project is active while retaining the "all projects" option for clearing filters

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14939c6ec83328545bfc4a28a9ae7