### PR TITLE
Disable project selector during new project wizard

### DIFF
--- a/frontend/src/components/app-sidebar.ts
+++ b/frontend/src/components/app-sidebar.ts
@@ -137,6 +137,8 @@ export class AppSidebar extends LocalizedElement {
   }
 
   private renderProjectSelectorMenuItems() {
+    const inWizard = this.activePath.startsWith('/projects/new');
+
     if (!this.projects.length) {
       return html`<span class="text-sm text-base-content/70">${t('app.projectSelector.empty')}</span>`;
     }
@@ -154,6 +156,7 @@ export class AppSidebar extends LocalizedElement {
           class="select select-bordered select-sm"
           @change=${this.handleProjectChange}
           .value=${this.activeProjectId ?? ''}
+          ?disabled=${inWizard}
         >
           <option value="">${emptyOptionLabel}</option>
           ${this.projects.map(
@@ -162,6 +165,11 @@ export class AppSidebar extends LocalizedElement {
             </option>`
           )}
         </select>
+        ${inWizard
+          ? html`<p class="mt-1 text-xs text-base-content/60">${t(
+              'app.projectSelector.wizardDisabled'
+            )}</p>`
+          : null}
       </label>
     `;
   }

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -32,7 +32,8 @@ const resources = {
           title: "Proyecto activo",
           placeholder: "Seleccionar Proyecto",
           all: "Todos los proyectos",
-          empty: "Sin proyectos activos"
+          empty: "Sin proyectos activos",
+          wizardDisabled: "No disponible durante la creación de un proyecto."
         },
         layout: {
           defaultProjectTitle: "Panel de control",
@@ -907,7 +908,8 @@ const resources = {
           title: "Active project",
           placeholder: "Select project",
           all: "All projects",
-          empty: "No active projects"
+          empty: "No active projects",
+          wizardDisabled: "Disabled while creating a new project."
         },
         layout: {
           defaultProjectTitle: "Dashboard",
@@ -1646,7 +1648,8 @@ const resources = {
           title: "Projecte actiu",
           placeholder: "Seleccionar projecte",
           all: "Tots els projectes",
-          empty: "Sense projectes actius"
+          empty: "Sense projectes actius",
+          wizardDisabled: "No es pot canviar mentre crees un projecte nou."
         },
         layout: {
           defaultProjectTitle: "Quadre de comandament",
@@ -2385,7 +2388,8 @@ const resources = {
           title: "Projet actif",
           placeholder: "Sélectionner un projet",
           all: "Tous les projets",
-          empty: "Aucun projet actif"
+          empty: "Aucun projet actif",
+          wizardDisabled: "Indisponible pendant la création d'un nouveau projet."
         },
         layout: {
           defaultProjectTitle: "Tableau de bord",


### PR DESCRIPTION
## Summary
- disable the sidebar project selector while the new project wizard is active
- show a helper message explaining why the selector is disabled
- add translations for the helper message in all supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e14b463a948332b4a03216b7e2fdbb