### PR TITLE
Fix contextual navigation when switching active project

### DIFF
--- a/frontend/src/components/app-shell.ts
+++ b/frontend/src/components/app-shell.ts
@@ -79,7 +79,31 @@ export class AppShell extends LocalizedElement {
   }
 
   private handleProjectChange(projectId: string | null) {
+    const currentPath = getCurrentPath();
+    const isProjectContextRoute = /^\/projects\/[^/]+(?:\/.*)?$/.test(currentPath);
+
     this.projects.value.setActiveProjectId(projectId);
+
+    if (!projectId) {
+      if (isProjectContextRoute) {
+        navigateTo('/projects');
+        this.syncActivePath();
+      }
+      return;
+    }
+
+    if (isProjectContextRoute) {
+      const segments = currentPath.split('/');
+      if (segments.length > 2) {
+        segments[2] = projectId;
+        const newPath = segments.join('/');
+
+        if (newPath !== currentPath) {
+          navigateTo(newPath, { replace: true });
+          this.syncActivePath();
+        }
+      }
+    }
   }
 
   private logout() {


### PR DESCRIPTION
## Summary
- update the app shell to realign contextual routes when the active project is changed from the selector
- ensure clearing the active project redirects back to the generic projects view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14e30657c83329f07aa4840eed1b6