### PR TITLE
Anchor mobile sidebar to the viewport edge

### DIFF
--- a/frontend/src/components/app-header.ts
+++ b/frontend/src/components/app-header.ts
@@ -22,6 +22,7 @@ export class AppHeader extends LocalizedElement {
   @property({ attribute: false }) supportedLanguages: ReadonlyArray<SupportedLanguage> = [];
   @property({ type: String }) userFullName: string | null = null;
   @property({ type: String }) userEmail: string | null = null;
+  @property({ type: Boolean }) mobileMenuOpen = false;
 
   private getUserInitials() {
     const nameSource = this.userFullName?.trim();
@@ -87,6 +88,8 @@ export class AppHeader extends LocalizedElement {
               class="btn btn-ghost btn-square btn-sm"
               @click=${this.toggleMenu}
               aria-label=${t('app.menuToggle')}
+              aria-expanded=${this.mobileMenuOpen ? 'true' : 'false'}
+              aria-controls="app-main-navigation"
             >
               <span class="text-xl leading-none">☰</span>
             </button>

--- a/frontend/src/components/app-shell.ts
+++ b/frontend/src/components/app-shell.ts
@@ -36,6 +36,12 @@ export class AppShell extends LocalizedElement {
     this.activePath = getCurrentPath();
   };
 
+  private readonly handleEscapeKey = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && this.mobileMenuOpen) {
+      this.mobileMenuOpen = false;
+    }
+  };
+
   private handlePendingActions() {
     const scrollToPendingActions = () => {
       const target = document.getElementById('pending-actions');
@@ -83,6 +89,7 @@ export class AppShell extends LocalizedElement {
     const isProjectContextRoute = /^\/projects\/[^/]+(?:\/.*)?$/.test(currentPath);
 
     this.projects.value.setActiveProjectId(projectId);
+    this.mobileMenuOpen = false;
 
     if (!projectId) {
       if (isProjectContextRoute) {
@@ -118,6 +125,7 @@ export class AppShell extends LocalizedElement {
     window.addEventListener('online', this.updateOnlineStatus);
     window.addEventListener('offline', this.updateOnlineStatus);
     window.addEventListener('popstate', this.syncActivePath);
+    window.addEventListener('keydown', this.handleEscapeKey);
   }
 
   disconnectedCallback(): void {
@@ -125,6 +133,7 @@ export class AppShell extends LocalizedElement {
     window.removeEventListener('online', this.updateOnlineStatus);
     window.removeEventListener('offline', this.updateOnlineStatus);
     window.removeEventListener('popstate', this.syncActivePath);
+    window.removeEventListener('keydown', this.handleEscapeKey);
   }
 
   protected override handleLanguageChanged(language: SupportedLanguage): void {
@@ -141,9 +150,17 @@ export class AppShell extends LocalizedElement {
   protected render() {
     const user = this.auth.user;
     const activeProject = this.projects.activeProject;
+    const showMobileOverlay = this.mobileMenuOpen;
 
     return html`
       <div class="min-h-screen flex bg-base-200 text-base-content">
+        ${showMobileOverlay
+          ? html`<div
+              class="fixed inset-0 bg-base-content/30 backdrop-blur-sm z-20 lg:hidden"
+              role="presentation"
+              @click=${this.toggleMenu}
+            ></div>`
+          : null}
         <app-sidebar
           .mobileMenuOpen=${this.mobileMenuOpen}
           .activeProject=${activeProject}
@@ -159,6 +176,7 @@ export class AppShell extends LocalizedElement {
             .activeProject=${activeProject}
             .language=${this.language}
             .supportedLanguages=${supportedLanguages}
+            .mobileMenuOpen=${this.mobileMenuOpen}
             .userFullName=${user?.full_name ?? null}
             .userEmail=${user?.email ?? null}
             @toggle-menu=${this.toggleMenu}

--- a/frontend/src/components/app-sidebar.ts
+++ b/frontend/src/components/app-sidebar.ts
@@ -179,8 +179,9 @@ export class AppSidebar extends LocalizedElement {
 
     return html`
       <aside
+        id="app-main-navigation"
         class=${classMap({
-          'w-72 bg-base-100 border-r border-base-300 flex flex-col fixed inset-y-0 z-30 transform transition-transform lg:static lg:translate-x-0':
+          'w-72 bg-base-100 border-r border-base-300 flex flex-col fixed inset-y-0 left-0 z-30 transform transition-transform lg:static lg:translate-x-0':
             true,
           '-translate-x-full lg:translate-x-0': !this.mobileMenuOpen,
           'translate-x-0': this.mobileMenuOpen


### PR DESCRIPTION
## Summary
- anchor the mobile sidebar to the left edge so it slides fully into view when opened

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e150fe17688332a0e8ceabc3de279f