### PR TITLE
Add backend risk evaluation endpoint and wire wizard to API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,7 @@ load_dotenv()
 
 from backend.database import SessionLocal, get_db, init_db
 from backend.services.email_service import send_registration_code_email, send_welcome_email
+from backend.services.risk_evaluation_service import evaluate_risk
 from backend.repositories.pending_user_repository import (
     delete_pending_registration,
     get_pending_registration_by_id,
@@ -64,6 +65,8 @@ from backend.schemas import (
     ProjectUpdate,
     RACIEntry,
     RiskAssessment,
+    RiskEvaluationPayload,
+    RiskEvaluationResult,
     RiskWizardConfig,
     Settings,
     SignInPayload,
@@ -500,6 +503,15 @@ def update_project(
 @app.get("/configs/risk-wizard", response_model=RiskWizardConfig)
 def get_risk_wizard_config(current_user: User = Depends(get_current_user)):
     return RiskWizardConfig()
+
+
+@app.post("/risk-evaluations", response_model=RiskEvaluationResult)
+def create_risk_evaluation(
+    payload: RiskEvaluationPayload,
+    current_user: User = Depends(get_current_user),
+):
+    result = evaluate_risk(payload.answers)
+    return RiskEvaluationResult(**result)
 
 
 @app.get("/projects/{project_id}/risk", response_model=List[RiskAssessment])

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -18,6 +18,7 @@ from .org_structure import OrgStructure
 from .pending_activity import PendingActivity
 from .raci_entry import RACIEntry
 from .risk_assessment import RiskAssessment
+from .risk_evaluation import RiskEvaluationPayload, RiskEvaluationResult
 from .risk_wizard_config import RiskWizardConfig
 from .settings import Settings
 from .sign_in_payload import SignInPayload
@@ -55,6 +56,8 @@ __all__ = [
     "PendingActivity",
     "RACIEntry",
     "RiskAssessment",
+    "RiskEvaluationPayload",
+    "RiskEvaluationResult",
     "RiskWizardConfig",
     "Settings",
     "SignInPayload",

--- a/backend/schemas/risk_evaluation.py
+++ b/backend/schemas/risk_evaluation.py
@@ -1,0 +1,13 @@
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class RiskEvaluationPayload(BaseModel):
+    answers: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RiskEvaluationResult(BaseModel):
+    classification: str
+    justification: str
+    obligations: List[str] = Field(default_factory=list)

--- a/backend/services/risk_evaluation_service.py
+++ b/backend/services/risk_evaluation_service.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+
+RiskAnswers = Dict[str, Any]
+
+
+def _config_path() -> Path:
+    # The risk wizard configuration currently lives in the frontend package.
+    # We reuse it directly to ensure both client and server rely on the same
+    # source of truth for rules.
+    return (
+        Path(__file__)
+        .resolve()
+        .parents[2]
+        / "frontend"
+        / "src"
+        / "configs"
+        / "risk-wizard.json"
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_result_step() -> Dict[str, Any]:
+    config_file = _config_path()
+    with config_file.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    steps: Iterable[Dict[str, Any]] = payload.get("wizard", {}).get("steps", [])
+    for step in steps:
+        if "rules" in step and "default" in step:
+            return step
+    raise ValueError("risk wizard configuration missing result step definition")
+
+
+def _is_not_empty(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip() != ""
+    if isinstance(value, (list, tuple, set)):
+        return len(value) > 0
+    return value is not None and value is not False
+
+
+def _matches_condition(expected: Any, answer: Any) -> bool:
+    if expected == "not_empty":
+        return _is_not_empty(answer)
+    if isinstance(expected, list):
+        if isinstance(answer, list):
+            return any(item in answer for item in expected)
+        return answer in expected
+    return answer == expected
+
+
+def _matches_rule(conditions: Dict[str, Any], answers: RiskAnswers) -> bool:
+    for question_id, expected in conditions.items():
+        if not _matches_condition(expected, answers.get(question_id)):
+            return False
+    return True
+
+
+_OBLIGATIONS_MAP: Dict[str, List[str]] = {
+    "alto": [
+        "Realizar la evaluación de conformidad completa según el Anexo VI.",
+        "Registrar el sistema en la base de datos de la UE antes de su puesta en el mercado.",
+        "Implementar un sistema continuo de gestión de riesgos.",
+        "Garantizar la gobernanza de los datos y su calidad durante entrenamiento y prueba.",
+        "Asegurar niveles adecuados de supervisión humana y ciberseguridad.",
+    ],
+    "limitado": [
+        "Informar claramente a los usuarios cuando interactúan con un sistema de IA.",
+        "Etiquetar de forma visible el contenido generado o manipulado mediante IA.",
+        "Revisar periódicamente si los casos de uso evolucionan hacia categorías de mayor riesgo.",
+    ],
+    "minimo": [
+        "Adherirse voluntariamente a códigos de conducta para fomentar la confianza.",
+        "Monitorizar el uso para detectar riesgos emergentes no contemplados inicialmente.",
+        "No se requieren acciones obligatorias de cumplimiento.",
+    ],
+}
+
+
+def evaluate_risk(answers: RiskAnswers) -> Dict[str, Any]:
+    result_step = _load_result_step()
+    rules = result_step.get("rules", [])
+
+    for rule in rules:
+        conditions = rule.get("if", {})
+        if _matches_rule(conditions, answers):
+            classification = rule.get("classification", "limitado")
+            return {
+                "classification": classification,
+                "justification": rule.get("justification", ""),
+                "obligations": _OBLIGATIONS_MAP.get(classification, []),
+            }
+
+    default_result = result_step.get("default", {})
+    classification = default_result.get("classification", "limitado")
+    return {
+        "classification": classification,
+        "justification": default_result.get("justification", ""),
+        "obligations": _OBLIGATIONS_MAP.get(classification, []),
+    }

--- a/frontend/src/pages/Projects/Model/ProjectWizardModels.ts
+++ b/frontend/src/pages/Projects/Model/ProjectWizardModels.ts
@@ -39,6 +39,7 @@ export type RiskWizardRule = {
 export type RiskWizardResult = {
   classification: RiskLevel;
   justification: string;
+  obligations: string[];
 };
 
 export type RiskWizardStep = {

--- a/frontend/src/pages/Projects/Service/risk-evaluation.service.ts
+++ b/frontend/src/pages/Projects/Service/risk-evaluation.service.ts
@@ -1,0 +1,42 @@
+import type { RiskLevel } from '../../../domain/models'
+import { api } from '../../../services/api'
+
+export type RiskEvaluationRequest = {
+  answers: Record<string, unknown>
+}
+
+export type RiskEvaluationResponse = {
+  classification: RiskLevel
+  justification: string
+  obligations: string[]
+}
+
+export class RiskEvaluationService {
+  #loading = false
+  #error: Error | null = null
+
+  get loading(): boolean {
+    return this.#loading
+  }
+
+  get error(): Error | null {
+    return this.#error
+  }
+
+  async evaluate(request: RiskEvaluationRequest): Promise<RiskEvaluationResponse> {
+    this.#loading = true
+    this.#error = null
+    try {
+      return await api<RiskEvaluationResponse>('/risk-evaluations', {
+        method: 'POST',
+        body: JSON.stringify(request)
+      })
+    } catch (error) {
+      const normalized = error instanceof Error ? error : new Error('Unknown error')
+      this.#error = normalized
+      throw normalized
+    } finally {
+      this.#loading = false
+    }
+  }
+}

--- a/frontend/src/pages/Projects/projects-wizard-page.ts
+++ b/frontend/src/pages/Projects/projects-wizard-page.ts
@@ -500,15 +500,88 @@ export class ProjectsWizardPage extends LocalizedElement {
 
   private renderRiskResult() {
     const result = this.#viewModel.riskResult;
-    if (!result) {
-      return null;
+    const loading = this.#viewModel.isRiskEvaluationLoading;
+    const error = this.#viewModel.riskEvaluationError;
+
+    if (loading) {
+      return html`
+        <article class="rounded-lg border border-base-300 bg-base-200/40 p-4">
+          <div class="flex items-center gap-3">
+            <span class="loading loading-spinner loading-md"></span>
+            <span class="text-sm text-base-content/70">${t('projects.wizard.risk.evaluation.loading')}</span>
+          </div>
+        </article>
+
+        <label class="form-control">
+          <span class="label"><span class="label-text">${t('projects.wizard.fields.notes')}</span></span>
+          <textarea
+            class="textarea textarea-bordered"
+            rows="4"
+            .value=${this.#viewModel.notes}
+            placeholder=${t('projects.wizard.placeholders.notes')}
+            @input=${(event: Event) => {
+              const textarea = event.currentTarget as HTMLTextAreaElement;
+              this.#viewModel.setNotes(textarea.value);
+            }}
+          ></textarea>
+        </label>
+      `;
     }
+
+    if (error) {
+      return html`
+        <div class="alert alert-error flex-col items-start gap-2">
+          <div>
+            <p class="font-semibold">${t('projects.wizard.risk.evaluation.error')}</p>
+            <p class="text-sm">${error}</p>
+          </div>
+          <button class="btn btn-sm" type="button" @click=${() => this.#viewModel.retryRiskEvaluation()}>
+            ${t('common.retry')}
+          </button>
+        </div>
+
+        <label class="form-control mt-4">
+          <span class="label"><span class="label-text">${t('projects.wizard.fields.notes')}</span></span>
+          <textarea
+            class="textarea textarea-bordered"
+            rows="4"
+            .value=${this.#viewModel.notes}
+            placeholder=${t('projects.wizard.placeholders.notes')}
+            @input=${(event: Event) => {
+              const textarea = event.currentTarget as HTMLTextAreaElement;
+              this.#viewModel.setNotes(textarea.value);
+            }}
+          ></textarea>
+        </label>
+      `;
+    }
+
+    if (!result) {
+      return html`
+        <p class="rounded-lg border border-dashed border-base-300 bg-base-200/40 p-4 text-sm text-base-content/70">
+          ${t('projects.wizard.risk.evaluation.awaiting')}
+        </p>
+
+        <label class="form-control mt-4">
+          <span class="label"><span class="label-text">${t('projects.wizard.fields.notes')}</span></span>
+          <textarea
+            class="textarea textarea-bordered"
+            rows="4"
+            .value=${this.#viewModel.notes}
+            placeholder=${t('projects.wizard.placeholders.notes')}
+            @input=${(event: Event) => {
+              const textarea = event.currentTarget as HTMLTextAreaElement;
+              this.#viewModel.setNotes(textarea.value);
+            }}
+          ></textarea>
+        </label>
+      `;
+    }
+
     const classificationBadge = this.renderRiskBadge(result.classification);
     const resultCopyKey = `riskWizard.results.${result.classification}` as const;
     const implications = t(`${resultCopyKey}.implications` as const);
-    const nextSteps = t(`${resultCopyKey}.next_steps` as const, {
-      returnObjects: true
-    }) as string[];
+    const obligations = Array.isArray(result.obligations) ? result.obligations : [];
 
     return html`
       <article class="rounded-lg border border-base-300 bg-base-200/40 p-4">
@@ -533,14 +606,14 @@ export class ProjectsWizardPage extends LocalizedElement {
               <p class="text-sm text-base-content/80">${implications}</p>`
           : null}
 
-        ${Array.isArray(nextSteps) && nextSteps.length
+        ${obligations.length
           ? html`
               <div class="mt-4">
                 <p class="text-sm font-medium text-base-content/70">
                   ${t('riskWizard.result.nextSteps')}
                 </p>
                 <ul class="list-disc space-y-1 pl-5 text-sm">
-                  ${nextSteps.map((step) => html`<li>${step}</li>`)}
+                  ${obligations.map((step) => html`<li>${step}</li>`)}
                 </ul>
               </div>
             `

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -187,7 +187,8 @@ const resources = {
         loading: "Cargando…",
         notFound: "No encontrado",
         notAvailable: "N/D",
-        remove: "Eliminar"
+        remove: "Eliminar",
+        retry: "Reintentar"
       },
       dashboard: {
         pageTitle: "Panel de control",
@@ -557,10 +558,15 @@ const resources = {
               internal_only: "Uso interno únicamente"
             }
           },
-          risk: {
-            description: "Selecciona la clasificación de riesgo identificada tras la evaluación inicial.",
-            option: "Riesgo {{risk}}"
-          },
+        risk: {
+          description: "Selecciona la clasificación de riesgo identificada tras la evaluación inicial.",
+          option: "Riesgo {{risk}}",
+          evaluation: {
+            loading: "Calculando clasificación de riesgo...",
+            error: "No se pudo obtener la clasificación. Vuelve a intentarlo.",
+            awaiting: "Completa el cuestionario para obtener la clasificación."
+          }
+        },
           team: {
             empty: "Todavía no hay contactos asignados.",
             form: {
@@ -1119,7 +1125,8 @@ const resources = {
         loading: "Loading…",
         notFound: "Not found",
         notAvailable: "N/A",
-        remove: "Remove"
+        remove: "Remove",
+        retry: "Retry"
       },
       dashboard: {
         pageTitle: "Dashboard",
@@ -1299,7 +1306,12 @@ const resources = {
           },
           risk: {
             description: "Select the risk classification identified after the initial assessment.",
-            option: "{{risk}} risk"
+            option: "{{risk}} risk",
+            evaluation: {
+              loading: "Evaluating risk classification...",
+              error: "We couldn't retrieve the classification. Please try again.",
+              awaiting: "Complete the questionnaire to get the classification."
+            }
           },
           team: {
             empty: "No contacts added yet.",
@@ -1859,7 +1871,8 @@ const resources = {
         loading: "Carregant…",
         notFound: "No s'ha trobat",
         notAvailable: "N/D",
-        remove: "Elimina"
+        remove: "Elimina",
+        retry: "Torna a provar"
       },
       dashboard: {
         pageTitle: "Quadre de control",
@@ -2039,7 +2052,12 @@ const resources = {
           },
           risk: {
             description: "Selecciona la classificació de risc identificada després de l'avaluació inicial.",
-            option: "Risc {{risk}}"
+            option: "Risc {{risk}}",
+            evaluation: {
+              loading: "Calculant la classificació de risc...",
+              error: "No s'ha pogut obtenir la classificació. Torna-ho a intentar.",
+              awaiting: "Completa el qüestionari per obtenir la classificació."
+            }
           },
           team: {
             empty: "Encara no hi ha contactes assignats.",
@@ -2599,7 +2617,8 @@ const resources = {
         loading: "Chargement…",
         notFound: "Introuvable",
         notAvailable: "N/D",
-        remove: "Supprimer"
+        remove: "Supprimer",
+        retry: "Réessayer"
       },
       dashboard: {
         pageTitle: "Tableau de bord",
@@ -2779,7 +2798,12 @@ const resources = {
           },
           risk: {
             description: "Sélectionnez la classification de risque identifiée après l'évaluation initiale.",
-            option: "Risque {{risk}}"
+            option: "Risque {{risk}}",
+            evaluation: {
+              loading: "Calcul de la classification de risque...",
+              error: "Impossible de récupérer la classification. Veuillez réessayer.",
+              awaiting: "Complétez le questionnaire pour obtenir la classification."
+            }
           },
           team: {
             empty: "Aucun contact ajouté pour le moment.",


### PR DESCRIPTION
## Summary
- add a shared backend service to evaluate questionnaire answers and expose it via POST /risk-evaluations
- introduce a frontend risk evaluation service and connect the project wizard to fetch classifications, obligations, and handle retries
- refresh wizard UI to show loading/error states, persist remote results, and extend i18n resources for the new flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e184a70eac8332a1dbfa296ac111cc