### PR TITLE
feat: persist wizard projects and deliverables

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -98,8 +98,12 @@ class ProjectModel(Base):
     role: Mapped[str] = mapped_column(String(50), nullable=False)
     risk: Mapped[str | None] = mapped_column(String(50), nullable=True)
     documentation_status: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    purpose: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    owner: Mapped[str | None] = mapped_column(String(255), nullable=True)
     business_units: Mapped[List[str] | None] = mapped_column(JSON, nullable=True)
     team: Mapped[List[str] | None] = mapped_column(JSON, nullable=True)
+    deployments: Mapped[List[str] | None] = mapped_column(JSON, nullable=True)
+    initial_risk_assessment: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utc_now, onupdate=utc_now

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,4 +1,4 @@
-from .project import Project
+from .project import InitialRiskAssessment, Project, ProjectCreate
 from .project_update import ProjectUpdate
 from .audit import Audit
 from .contact import Contact
@@ -36,7 +36,9 @@ from .user import User
 from .user_preferences import UserPreferences
 
 __all__ = [
+    "InitialRiskAssessment",
     "Project",
+    "ProjectCreate",
     "ProjectUpdate",
     "Audit",
     "Contact",

--- a/backend/schemas/deliverable.py
+++ b/backend/schemas/deliverable.py
@@ -1,12 +1,15 @@
+from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Deliverable(BaseModel):
     id: str
     project_id: str
     name: str
-    version: Optional[str] = None
-    status: Optional[str] = None
+    type: str
+    version: int = 0
+    status: str = "Abierto"
     link: Optional[str] = None
+    updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/schemas/project.py
+++ b/backend/schemas/project.py
@@ -1,13 +1,36 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
-class Project(BaseModel):
-    id: str
+class RiskAnswer(BaseModel):
+    key: str
+    value: Any
+
+
+class InitialRiskAssessment(BaseModel):
+    classification: str
+    justification: str
+    answers: List[RiskAnswer] = Field(default_factory=list)
+
+
+class ProjectBase(BaseModel):
     name: str
     role: str  # provider/importer/distributor/user
     risk: Optional[str] = None
     documentation_status: Optional[str] = None
+    purpose: Optional[str] = None
+    owner: Optional[str] = None
     business_units: Optional[List[str]] = None
+    deployments: List[str] = Field(default_factory=list)
     team: Optional[List[str]] = None
+
+
+class Project(ProjectBase):
+    id: str
+    initial_risk_assessment: Optional[InitialRiskAssessment] = None
+
+
+class ProjectCreate(ProjectBase):
+    id: Optional[str] = None
+    initial_risk_assessment: Optional[InitialRiskAssessment] = None

--- a/backend/schemas/project_update.py
+++ b/backend/schemas/project_update.py
@@ -2,6 +2,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
+from .project import InitialRiskAssessment
+
 
 class ProjectUpdate(BaseModel):
     name: Optional[str] = None
@@ -10,3 +12,7 @@ class ProjectUpdate(BaseModel):
     documentation_status: Optional[str] = None
     business_units: Optional[List[str]] = None
     team: Optional[List[str]] = None
+    purpose: Optional[str] = None
+    owner: Optional[str] = None
+    deployments: Optional[List[str]] = None
+    initial_risk_assessment: Optional[InitialRiskAssessment] = None

--- a/frontend/src/pages/Deliverables/Deliverables.viewmodel.ts
+++ b/frontend/src/pages/Deliverables/Deliverables.viewmodel.ts
@@ -1,5 +1,6 @@
 import type { DocumentRef, Task } from '../../domain/models';
 import type { ProjectStore } from '../../state/project-store';
+import { fetchProjectDeliverables } from '../Projects/Service/projects.service';
 
 export class DeliverablesViewModel {
   constructor(private readonly store: ProjectStore) {}
@@ -12,6 +13,12 @@ export class DeliverablesViewModel {
   getDocuments(projectId: string | null): DocumentRef[] {
     if (!projectId) return [];
     return this.store.getDocumentsByProjectId(projectId);
+  }
+
+  async refreshDocuments(projectId: string): Promise<DocumentRef[]> {
+    const documents = await fetchProjectDeliverables(projectId);
+    this.store.setDocumentsForProject(projectId, documents);
+    return documents;
   }
 
   uploadNewVersion(docId: string, currentVersion: number) {

--- a/frontend/src/pages/Projects/Service/projects.service.ts
+++ b/frontend/src/pages/Projects/Service/projects.service.ts
@@ -1,14 +1,236 @@
+import type {
+  AISystem,
+  DeliverableType,
+  DocumentRef,
+  RiskAnswer,
+  RiskLevel,
+} from '../../../domain/models'
 import { systems } from '../../../mocks/data'
-import type { AISystem } from '../../../domain/models'
-import { ProjectFilter } from '../Model'
+import { api, tryApi } from '../../../services/api'
+import type { ProjectFilter } from '../Model'
 
-export async function fetchSystems(filter: ProjectFilter): Promise<AISystem[]> {
-  await new Promise(r => setTimeout(r, 100)) // mock latency
-  return systems.filter(s => {
-    const byRole = filter.role ? s.role === filter.role : true
-    const byRisk = filter.risk ? s.risk === filter.risk : true
-    const byDoc = filter.doc ? (s.docStatus === filter.doc) : true
-    const byQ = filter.q ? s.name.toLowerCase().includes(filter.q.toLowerCase()) : true
-    return byRole && byRisk && byDoc && byQ
+type ProjectApi = {
+  id: string
+  name: string
+  role: AISystem['role']
+  risk?: string | null
+  documentation_status?: string | null
+  purpose?: string | null
+  owner?: string | null
+  business_units?: string[] | null
+  deployments?: string[] | null
+  team?: string[] | null
+  initial_risk_assessment?: {
+    classification: string
+    justification: string
+    answers?: Array<{ key: string; value: unknown }>
+  } | null
+}
+
+type DeliverableApi = {
+  id: string
+  project_id: string
+  name: string
+  type?: string | null
+  version?: number | null
+  status?: string | null
+  link?: string | null
+  updated_at?: string | null
+}
+
+export type CreateProjectRequest = {
+  name: string
+  role: AISystem['role']
+  purpose: string
+  owner: string
+  businessUnit?: string
+  documentationStatus?: string
+  deployments: string[]
+  risk?: RiskLevel
+  riskAssessment?: {
+    classification: RiskLevel
+    justification: string
+    answers: RiskAnswer[]
+  }
+}
+
+type CreateProjectPayload = {
+  name: string
+  role: AISystem['role']
+  purpose: string
+  owner: string
+  business_units?: string[]
+  documentation_status?: string
+  deployments: string[]
+  risk?: string
+  initial_risk_assessment?: {
+    classification: string
+    justification: string
+    answers: RiskAnswer[]
+  }
+}
+
+type CreateProjectResponse = ProjectApi
+
+const RISK_MAP_TO_DOMAIN: Record<string, RiskLevel> = {
+  high: 'alto',
+  medium: 'limitado',
+  low: 'minimo',
+  unacceptable: 'inaceptable',
+}
+
+const DOC_STATUS_MAP_TO_DOMAIN: Record<string, AISystem['docStatus']> = {
+  in_progress: 'borrador',
+  not_started: 'borrador',
+  completed: 'vigente',
+  obsolete: 'obsoleta',
+}
+
+const DEFAULT_DELIVERABLE_STATUS: DocumentRef['status'] = 'Abierto'
+
+function mapRiskToDomain(value: string | null | undefined): RiskLevel | undefined {
+  if (!value) return undefined
+  return RISK_MAP_TO_DOMAIN[value] ?? (value as RiskLevel)
+}
+
+function mapDocStatusToDomain(
+  value: string | null | undefined,
+): AISystem['docStatus'] | undefined {
+  if (!value) return undefined
+  return DOC_STATUS_MAP_TO_DOMAIN[value] ?? (value as AISystem['docStatus'])
+}
+
+function mapProjectFromApi(data: ProjectApi): AISystem {
+  const businessUnit = Array.isArray(data.business_units) ? data.business_units[0] : undefined
+  return {
+    id: data.id,
+    name: data.name,
+    role: data.role,
+    purpose: data.purpose ?? undefined,
+    owner: data.owner ?? undefined,
+    businessUnit,
+    deployments: data.deployments ?? [],
+    team: undefined,
+    risk: mapRiskToDomain(data.risk ?? undefined),
+    docStatus: mapDocStatusToDomain(data.documentation_status ?? undefined),
+    lastAssessment: undefined,
+    tags: undefined,
+    initialRiskAssessment: data.initial_risk_assessment
+      ? {
+          classification: mapRiskToDomain(data.initial_risk_assessment.classification) ??
+            (data.initial_risk_assessment.classification as RiskLevel),
+          justification: data.initial_risk_assessment.justification,
+          answers: (data.initial_risk_assessment.answers ?? []).map((answer) => ({
+            key: answer.key,
+            value: answer.value,
+          })),
+        }
+      : undefined,
+  }
+}
+
+function mapSystemToProjectApi(system: AISystem): ProjectApi {
+  return {
+    id: system.id,
+    name: system.name,
+    role: system.role,
+    risk: system.risk,
+    documentation_status: system.docStatus,
+    purpose: system.purpose ?? null,
+    owner: system.owner ?? null,
+    business_units: system.businessUnit ? [system.businessUnit] : null,
+    deployments: system.deployments ?? null,
+    team: Array.isArray(system.team) ? system.team.map((member) => member.email) : null,
+    initial_risk_assessment: system.initialRiskAssessment
+      ? {
+          classification: system.initialRiskAssessment.classification,
+          justification: system.initialRiskAssessment.justification,
+          answers: system.initialRiskAssessment.answers.map((answer) => ({ ...answer })),
+        }
+      : null,
+  }
+}
+
+function mapDeliverableFromApi(data: DeliverableApi): DocumentRef {
+  const version = typeof data.version === 'number' ? data.version : 0
+  const type = (data.type as DeliverableType | undefined) ?? 'other'
+  const status = (data.status as DocumentRef['status'] | undefined) ?? DEFAULT_DELIVERABLE_STATUS
+  return {
+    id: data.id,
+    systemId: data.project_id,
+    name: data.name,
+    type,
+    version,
+    status,
+    updatedAt: data.updated_at ?? new Date().toISOString(),
+    link: data.link ?? undefined,
+  }
+}
+
+function mapFilterToQuery(filter: ProjectFilter): string {
+  const params = new URLSearchParams()
+  if (filter.role) params.set('role', filter.role)
+  if (filter.risk) params.set('risk', filter.risk)
+  if (filter.doc) params.set('doc', filter.doc)
+  if (filter.q) params.set('q', filter.q)
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}
+
+function buildCreatePayload(request: CreateProjectRequest): CreateProjectPayload {
+  const payload: CreateProjectPayload = {
+    name: request.name.trim(),
+    role: request.role,
+    purpose: request.purpose.trim(),
+    owner: request.owner.trim(),
+    deployments: [...request.deployments],
+  }
+
+  if (request.businessUnit) {
+    payload.business_units = [request.businessUnit]
+  }
+  if (request.documentationStatus) {
+    payload.documentation_status = request.documentationStatus
+  }
+  if (request.risk) {
+    payload.risk = request.risk
+  }
+  if (request.riskAssessment) {
+    payload.initial_risk_assessment = {
+      classification: request.riskAssessment.classification,
+      justification: request.riskAssessment.justification,
+      answers: request.riskAssessment.answers.map((answer) => ({ ...answer })),
+    }
+  }
+
+  return payload
+}
+
+export async function fetchProjects(filter: ProjectFilter = {}): Promise<AISystem[]> {
+  const query = mapFilterToQuery(filter)
+  const projects = await tryApi(
+    async () => await api<ProjectApi[]>(`/projects${query}`),
+    async () => systems.map(mapSystemToProjectApi),
+  )
+  return projects.map(mapProjectFromApi)
+}
+
+export async function fetchProjectDeliverables(projectId: string): Promise<DocumentRef[]> {
+  const deliverables = await tryApi(
+    async () => await api<DeliverableApi[]>(`/projects/${projectId}/deliverables`),
+    async () => [],
+  )
+  return deliverables.map(mapDeliverableFromApi)
+}
+
+export async function createProject(
+  request: CreateProjectRequest,
+): Promise<{ projectId: string; project: AISystem }> {
+  const payload = buildCreatePayload(request)
+  const response = await api<CreateProjectResponse>('/projects', {
+    method: 'POST',
+    body: JSON.stringify(payload),
   })
+  const project = mapProjectFromApi(response)
+  return { projectId: project.id, project }
 }

--- a/frontend/src/pages/Projects/projects-wizard-page.ts
+++ b/frontend/src/pages/Projects/projects-wizard-page.ts
@@ -739,7 +739,7 @@ export class ProjectsWizardPage extends LocalizedElement {
   };
 
   private handleNext = () => {
-    this.#viewModel.goNext();
+    void this.#viewModel.goNext();
   };
 
   private canContinueToNextStep(): boolean {
@@ -748,6 +748,11 @@ export class ProjectsWizardPage extends LocalizedElement {
 
   protected render() {
     const canContinue = this.canContinueToNextStep();
+    const isSubmitting = this.#viewModel.isSubmitting;
+    const actionButtonClasses = ['btn', 'btn-primary'];
+    if (isSubmitting) {
+      actionButtonClasses.push('loading');
+    }
 
     return html`
       <section class="space-y-6">
@@ -758,24 +763,27 @@ export class ProjectsWizardPage extends LocalizedElement {
 
         ${this.renderStepIndicator()}
 
-        <div class="card bg-base-100 shadow">
-          <div class="card-body space-y-6">
-            ${this.renderCurrentStep()}
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <div class="flex flex-wrap gap-2">
-                <button class="btn btn-ghost" type="button" @click=${this.handleCancel}>
-                  ${t('common.cancel')}
-                </button>
-                <button class="btn" type="button" ?disabled=${this.#viewModel.step === 0} @click=${this.handlePrevious}>
-                  ${t('common.back')}
+          <div class="card bg-base-100 shadow">
+            <div class="card-body space-y-6">
+              ${this.renderCurrentStep()}
+              ${this.#viewModel.submissionError
+                ? html`<div class="alert alert-error"><span>${this.#viewModel.submissionError}</span></div>`
+                : null}
+              <div class="flex flex-wrap items-center justify-between gap-3">
+                <div class="flex flex-wrap gap-2">
+                  <button class="btn btn-ghost" type="button" @click=${this.handleCancel}>
+                    ${t('common.cancel')}
+                  </button>
+                  <button class="btn" type="button" ?disabled=${this.#viewModel.step === 0} @click=${this.handlePrevious}>
+                    ${t('common.back')}
+                  </button>
+                </div>
+                <button class=${actionButtonClasses.join(' ')} type="button" ?disabled=${!canContinue} @click=${this.handleNext}>
+                  ${this.#viewModel.step === this.#viewModel.steps.length - 1
+                    ? t('projects.wizard.finish')
+                    : t('common.next')}
                 </button>
               </div>
-              <button class="btn btn-primary" type="button" ?disabled=${!canContinue} @click=${this.handleNext}>
-                ${this.#viewModel.step === this.#viewModel.steps.length - 1
-                  ? t('projects.wizard.finish')
-                  : t('common.next')}
-              </button>
-            </div>
           </div>
         </div>
       </section>

--- a/frontend/src/state/project-store.ts
+++ b/frontend/src/state/project-store.ts
@@ -67,6 +67,19 @@ export class ProjectStore {
     this.activeProjectId.value = id;
   }
 
+  replaceProjects(projects: AISystem[]): void {
+    const cloned = projects.map((project) => ({ ...project }));
+    this.projects.value = cloned;
+  }
+
+  setDocumentsForProject(projectId: string, documents: DocumentRef[]): void {
+    const normalized = documents.map((doc) => ({ ...doc }));
+    this.documents.update((prev) => {
+      const others = prev.filter((doc) => doc.systemId !== projectId);
+      return [...others, ...normalized];
+    });
+  }
+
   createProject(input: CreateProjectInput): AISystem {
     const now = new Date();
     const newProject: AISystem = {


### PR DESCRIPTION
## Summary
- extend backend project schemas, repository, and API to accept wizard fields and create initial deliverables
- add frontend project service and update wizard submission to call the API, manage loading/error states, and refresh the store
- load deliverables from the backend in the deliverables page and update integration tests for the new workflow

## Testing
- pytest tests/test_projects_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e18caddc908332b191aef13263f2cc