### PR TITLE
feat: add deliverable scheduling wizard

### DIFF
--- a/frontend/src/domain/models.ts
+++ b/frontend/src/domain/models.ts
@@ -101,6 +101,8 @@ export interface DocumentRef {
   status: DeliverableStatus
   updatedAt: string
   link?: string
+  assignee?: string
+  dueDate?: string
 }
 
 export interface Incident {

--- a/frontend/src/pages/Deliverables/deliverables-scheduling-wizard.ts
+++ b/frontend/src/pages/Deliverables/deliverables-scheduling-wizard.ts
@@ -1,0 +1,339 @@
+import { html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { DocumentRef } from '../../domain/models';
+import { LocalizedElement } from '../../shared/localized-element';
+import { t } from '../../shared/i18n';
+
+@customElement('deliverables-scheduling-wizard')
+export class DeliverablesSchedulingWizard extends LocalizedElement {
+  declare renderRoot: HTMLElement;
+
+  @property({ type: Boolean }) open = false;
+  @property({ attribute: false }) deliverables: DocumentRef[] = [];
+  @property({ attribute: false }) team: Array<{ id: string; name: string }> = [];
+  @property({ type: String }) projectName = '';
+  @property({ attribute: false }) assignDeliverable?: (
+    deliverable: DocumentRef,
+    input: { assignee: string; dueDate: string; createTask: boolean }
+  ) => Promise<void>;
+
+  @state() private stepIndex = 0;
+  @state() private assignee = '';
+  @state() private dueDate = '';
+  @state() private createTask = true;
+  @state() private submitting = false;
+  @state() private error: string | null = null;
+
+  #confirmedDeliverables = new Set<string>();
+  #completionEmitted = false;
+  #initialPending = 0;
+
+  protected createRenderRoot(): HTMLElement {
+    return this;
+  }
+
+  private get pendingFromServer(): DocumentRef[] {
+    return this.deliverables.filter((doc) => !doc.assignee || !doc.dueDate);
+  }
+
+  private get wizardQueue(): DocumentRef[] {
+    const pending = this.pendingFromServer;
+    if (this.#confirmedDeliverables.size === 0) {
+      return pending;
+    }
+    return pending.filter((doc) => !this.#confirmedDeliverables.has(doc.id));
+  }
+
+  private get currentDeliverable(): DocumentRef | null {
+    return this.wizardQueue[this.stepIndex] ?? null;
+  }
+
+  private get remainingCount(): number {
+    return this.wizardQueue.length;
+  }
+
+  private get completedCount(): number {
+    if (this.#initialPending === 0) {
+      return 0;
+    }
+    const pending = this.pendingFromServer.length;
+    return Math.max(this.#initialPending - pending, 0);
+  }
+
+  protected override updated(changedProperties: Map<string, unknown>): void {
+    super.updated(changedProperties);
+
+    if (changedProperties.has('open')) {
+      if (this.open) {
+        this.#onOpen();
+      } else {
+        this.#onClose();
+      }
+    }
+
+    if (this.open && changedProperties.has('deliverables')) {
+      if (this.stepIndex >= this.wizardQueue.length && this.wizardQueue.length > 0) {
+        this.stepIndex = 0;
+      }
+      if (this.pendingFromServer.length === 0) {
+        this.#completeWizard();
+      }
+    }
+  }
+
+  #onOpen(): void {
+    this.assignee = '';
+    this.dueDate = '';
+    this.createTask = true;
+    this.stepIndex = 0;
+    this.error = null;
+    this.#confirmedDeliverables.clear();
+    this.#completionEmitted = false;
+    const pending = this.pendingFromServer.length;
+    this.#initialPending = pending;
+    if (pending === 0) {
+      this.#completeWizard();
+    }
+  }
+
+  #onClose(): void {
+    this.assignee = '';
+    this.dueDate = '';
+    this.createTask = true;
+    this.stepIndex = 0;
+    this.error = null;
+    this.#confirmedDeliverables.clear();
+    this.#completionEmitted = false;
+    this.#initialPending = 0;
+  }
+
+  async #handleConfirm(): Promise<void> {
+    const deliverable = this.currentDeliverable;
+    if (!deliverable || !this.assignDeliverable) {
+      return;
+    }
+    if (!this.assignee || !this.dueDate) {
+      return;
+    }
+
+    this.submitting = true;
+    this.error = null;
+
+    try {
+      await this.assignDeliverable(deliverable, {
+        assignee: this.assignee,
+        dueDate: this.dueDate,
+        createTask: this.createTask,
+      });
+      this.#confirmedDeliverables.add(deliverable.id);
+      this.assignee = '';
+      this.dueDate = '';
+      this.createTask = true;
+      if (this.wizardQueue.length === 0 && this.pendingFromServer.length === 0) {
+        this.#completeWizard();
+      } else {
+        this.stepIndex = 0;
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        this.error = error.message;
+      } else {
+        this.error = t('deliverables.notifications.assignmentFailed');
+      }
+    } finally {
+      this.submitting = false;
+    }
+  }
+
+  #completeWizard(): void {
+    if (this.#completionEmitted) {
+      return;
+    }
+    this.#completionEmitted = true;
+    this.dispatchEvent(
+      new CustomEvent('deliverables-wizard-complete', {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  #handleDismiss(): void {
+    this.#completeWizard();
+  }
+
+  #updateAssignee(event: Event): void {
+    const select = event.currentTarget as HTMLSelectElement;
+    this.assignee = select.value;
+  }
+
+  #updateDueDate(event: Event): void {
+    const input = event.currentTarget as HTMLInputElement;
+    this.dueDate = input.value;
+  }
+
+  #toggleCreateTask(event: Event): void {
+    const input = event.currentTarget as HTMLInputElement;
+    this.createTask = input.checked;
+  }
+
+  private renderQueue(): unknown {
+    const queue = this.wizardQueue;
+    if (queue.length === 0) {
+      return null;
+    }
+    return html`
+      <div class="space-y-2">
+        <h4 class="text-sm font-semibold uppercase tracking-wide">
+          ${t('deliverables.wizard.queueTitle')}
+        </h4>
+        <ul class="space-y-1 max-h-32 overflow-y-auto pr-1">
+          ${queue.map(
+            (item, index) => html`
+              <li
+                class="flex items-center gap-2 rounded-box px-2 py-1 ${index === 0
+                  ? 'bg-primary/10 text-primary'
+                  : 'bg-base-200'}"
+              >
+                <span class="badge badge-sm ${index === 0 ? 'badge-primary' : 'badge-ghost'}">
+                  ${index + 1}
+                </span>
+                <span class="text-sm ${index === 0 ? 'font-medium' : ''}">${item.name}</span>
+              </li>
+            `,
+          )}
+        </ul>
+      </div>
+    `;
+  }
+
+  private renderContent(): unknown {
+    if (!this.open) {
+      return null;
+    }
+
+    if (this.pendingFromServer.length === 0) {
+      return html`
+        <div class="modal modal-open">
+          <div class="modal-box space-y-4">
+            <h3 class="text-xl font-semibold">
+              ${t('deliverables.wizard.completedTitle')}
+            </h3>
+            <p class="text-sm text-base-content/70">
+              ${t('deliverables.wizard.completedDescription', {
+                project: this.projectName || t('common.notAvailable'),
+              })}
+            </p>
+            <div class="modal-action">
+              <button class="btn btn-primary" type="button" @click=${this.#handleDismiss}>
+                ${t('deliverables.wizard.close')}
+              </button>
+            </div>
+          </div>
+          <div class="modal-backdrop bg-neutral/50"></div>
+        </div>
+      `;
+    }
+
+    const deliverable = this.currentDeliverable;
+    const total = Math.max(this.#initialPending, this.completedCount + this.remainingCount);
+    const currentStep = Math.min(this.completedCount + 1, total);
+
+    return html`
+      <div class="modal modal-open">
+        <div class="modal-box max-w-3xl space-y-6">
+          <header class="space-y-2">
+            <h3 class="text-xl font-semibold">${t('deliverables.wizard.title')}</h3>
+            <p class="text-sm text-base-content/70">
+              ${t('deliverables.wizard.description', {
+                project: this.projectName || t('common.notAvailable'),
+              })}
+            </p>
+          </header>
+
+          <div class="flex flex-wrap items-center justify-between gap-2 text-sm">
+            <span class="badge badge-primary badge-outline">
+              ${t('deliverables.wizard.progress', {
+                current: currentStep,
+                total: Math.max(total, 1),
+              })}
+            </span>
+            <span class="text-base-content/70">
+              ${t('deliverables.wizard.remaining', { count: this.remainingCount })}
+            </span>
+          </div>
+
+          <div class="grid gap-6 md:grid-cols-[2fr,1fr]">
+            <div class="space-y-4">
+              <div class="space-y-1">
+                <h4 class="font-semibold text-lg">${deliverable?.name}</h4>
+                <p class="text-sm text-base-content/70">
+                  ${t('deliverables.wizard.instructions')}
+                </p>
+              </div>
+
+              <label class="form-control">
+                <span class="label">
+                  <span class="label-text">${t('deliverables.wizard.assigneeLabel')}</span>
+                </span>
+                <select class="select select-bordered" .value=${this.assignee} @change=${this.#updateAssignee}>
+                  <option value="">${t('deliverables.wizard.assigneePlaceholder')}</option>
+                  ${this.team.map(
+                    (member) => html`<option value=${member.name}>${member.name}</option>`,
+                  )}
+                </select>
+              </label>
+
+              <label class="form-control">
+                <span class="label">
+                  <span class="label-text">${t('deliverables.wizard.dueDateLabel')}</span>
+                </span>
+                <input
+                  class="input input-bordered"
+                  type="date"
+                  .value=${this.dueDate}
+                  @input=${this.#updateDueDate}
+                />
+              </label>
+
+              <label class="label cursor-pointer justify-start gap-3">
+                <input
+                  class="checkbox checkbox-primary"
+                  type="checkbox"
+                  .checked=${this.createTask}
+                  @change=${this.#toggleCreateTask}
+                />
+                <span class="label-text">${t('deliverables.wizard.createTask')}</span>
+              </label>
+
+              ${this.error
+                ? html`<div class="alert alert-error text-sm">${this.error}</div>`
+                : null}
+            </div>
+
+            ${this.renderQueue()}
+          </div>
+
+          <div class="modal-action">
+            <button
+              class="btn btn-primary"
+              type="button"
+              ?disabled=${!this.assignee || !this.dueDate || this.submitting}
+              @click=${this.#handleConfirm}
+            >
+              ${this.submitting
+                ? html`<span class="loading loading-spinner"></span>`
+                : null}
+              <span>${t('deliverables.wizard.confirm')}</span>
+            </button>
+          </div>
+        </div>
+        <div class="modal-backdrop bg-neutral/50"></div>
+      </div>
+    `;
+  }
+
+  protected render() {
+    return this.renderContent();
+  }
+}

--- a/frontend/src/pages/Projects/projects-wizard.viewmodel.ts
+++ b/frontend/src/pages/Projects/projects-wizard.viewmodel.ts
@@ -377,7 +377,7 @@ export class ProjectsWizardViewModel implements ReactiveController {
 
       this.#clearDraft(true);
       this.#resetWizardState();
-      navigateTo(`/projects/${projectId}/deliverables`, { replace: true });
+      navigateTo(`/projects/${projectId}/deliverables?wizard=schedule`, { replace: true });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Error inesperado';
       this.#setSubmitError(message);

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -152,6 +152,8 @@ const resources = {
           name: "Entregable",
           status: "Estado",
           version: "Versión",
+          assignee: "Responsable",
+          dueDate: "Plazo",
           actions: "Acciones"
         },
         actions: {
@@ -169,6 +171,31 @@ const resources = {
           assignee: "Asignar a",
           dueDate: "Fecha de entrega",
           placeholder: "Selecciona un contacto"
+        },
+        labels: {
+          unassigned: "Sin asignar",
+          noDueDate: "Sin fecha"
+        },
+        wizard: {
+          title: "Planifica la calendarización",
+          description: "Define responsable y fecha objetivo para cada entregable clave de {{project}}.",
+          progress: "Paso {{current}} de {{total}}",
+          remaining: "Pendientes: {{count}}",
+          queueTitle: "Próximos entregables",
+          instructions: "Selecciona la persona responsable y la fecha objetivo para continuar.",
+          assigneeLabel: "Responsable",
+          assigneePlaceholder: "Selecciona un miembro del equipo",
+          dueDateLabel: "Fecha objetivo",
+          createTask: "Crear tarea de seguimiento en el calendario",
+          confirm: "Confirmar asignación",
+          completedTitle: "¡Todo listo!",
+          completedDescription: "Todos los entregables del proyecto {{project}} tienen responsable y fecha comprometida.",
+          close: "Cerrar asistente"
+        },
+        notifications: {
+          assignmentCreated: "Asignación guardada para {{deliverable}}",
+          assignmentFailed: "No se pudo guardar la asignación",
+          assignmentsComplete: "Todos los entregables tienen responsable y fecha"
         }
       },
       languages: {
@@ -1034,6 +1061,8 @@ const resources = {
           name: "Deliverable",
           status: "Status",
           version: "Version",
+          assignee: "Owner",
+          dueDate: "Target date",
           actions: "Actions"
         },
         actions: {
@@ -1051,6 +1080,31 @@ const resources = {
           assignee: "Assign to",
           dueDate: "Due date",
           placeholder: "Select a contact"
+        },
+        labels: {
+          unassigned: "Unassigned",
+          noDueDate: "No date"
+        },
+        wizard: {
+          title: "Schedule the upcoming work",
+          description: "Choose an owner and a target date for each key deliverable in {{project}}.",
+          progress: "Step {{current}} of {{total}}",
+          remaining: "Remaining: {{count}}",
+          queueTitle: "Next deliverables",
+          instructions: "Pick the responsible person and deadline to continue.",
+          assigneeLabel: "Owner",
+          assigneePlaceholder: "Select a team member",
+          dueDateLabel: "Target date",
+          createTask: "Create a follow-up task on the calendar",
+          confirm: "Confirm assignment",
+          completedTitle: "All set!",
+          completedDescription: "Every deliverable in {{project}} now has an owner and a target date.",
+          close: "Close assistant"
+        },
+        notifications: {
+          assignmentCreated: "Assignment saved for {{deliverable}}",
+          assignmentFailed: "We couldn't save the assignment",
+          assignmentsComplete: "Every deliverable has an owner and a date"
         }
       },
       calendarWorkflows: {
@@ -1780,6 +1834,8 @@ const resources = {
           name: "Lliurable",
           status: "Estat",
           version: "Versió",
+          assignee: "Responsable",
+          dueDate: "Data límit",
           actions: "Accions"
         },
         actions: {
@@ -1797,6 +1853,31 @@ const resources = {
           assignee: "Assignar a",
           dueDate: "Data de lliurament",
           placeholder: "Selecciona un contacte"
+        },
+        labels: {
+          unassigned: "Sense assignar",
+          noDueDate: "Sense data"
+        },
+        wizard: {
+          title: "Planifica el seguiment",
+          description: "Defineix responsable i data objectiu per a cada lliurable clau de {{project}}.",
+          progress: "Pas {{current}} de {{total}}",
+          remaining: "Pendents: {{count}}",
+          queueTitle: "Lliurables pendents",
+          instructions: "Selecciona la persona responsable i la data objectiu per continuar.",
+          assigneeLabel: "Responsable",
+          assigneePlaceholder: "Selecciona un membre de l'equip",
+          dueDateLabel: "Data objectiu",
+          createTask: "Crear una tasca de seguiment al calendari",
+          confirm: "Confirmar assignació",
+          completedTitle: "Tot a punt!",
+          completedDescription: "Tots els lliurables de {{project}} tenen responsable i data comprometuda.",
+          close: "Tanca l'assistent"
+        },
+        notifications: {
+          assignmentCreated: "Assignació guardada per a {{deliverable}}",
+          assignmentFailed: "No s'ha pogut guardar l'assignació",
+          assignmentsComplete: "Tots els lliurables tenen responsable i data"
         }
       },
       calendarWorkflows: {
@@ -2526,6 +2607,8 @@ const resources = {
           name: "Livrable",
           status: "Statut",
           version: "Version",
+          assignee: "Responsable",
+          dueDate: "Échéance",
           actions: "Actions"
         },
         actions: {
@@ -2543,6 +2626,31 @@ const resources = {
           assignee: "Assigner à",
           dueDate: "Date d'échéance",
           placeholder: "Sélectionnez un contact"
+        },
+        labels: {
+          unassigned: "Non attribué",
+          noDueDate: "Sans date"
+        },
+        wizard: {
+          title: "Planifier le suivi",
+          description: "Définissez un responsable et une date cible pour chaque livrable clé de {{project}}.",
+          progress: "Étape {{current}} sur {{total}}",
+          remaining: "Restants : {{count}}",
+          queueTitle: "Livrables en attente",
+          instructions: "Sélectionnez la personne responsable et la date cible pour continuer.",
+          assigneeLabel: "Responsable",
+          assigneePlaceholder: "Sélectionnez un membre de l'équipe",
+          dueDateLabel: "Date cible",
+          createTask: "Créer une tâche de suivi dans le calendrier",
+          confirm: "Confirmer l'assignation",
+          completedTitle: "C'est fait !",
+          completedDescription: "Tous les livrables de {{project}} ont un responsable et une date cible.",
+          close: "Fermer l'assistant"
+        },
+        notifications: {
+          assignmentCreated: "Assignation enregistrée pour {{deliverable}}",
+          assignmentFailed: "Impossible d'enregistrer l'assignation",
+          assignmentsComplete: "Tous les livrables ont un responsable et une date"
         }
       },
       calendarWorkflows: {

--- a/frontend/src/state/project-store.ts
+++ b/frontend/src/state/project-store.ts
@@ -124,12 +124,38 @@ export class ProjectStore {
     );
   }
 
+  updateDeliverableAssignment(
+    deliverableId: string,
+    assignment: { assignee: string; dueDate?: string | null }
+  ): void {
+    this.documents.update((docs) =>
+      docs.map((doc) =>
+        doc.id === deliverableId
+          ? { ...doc, assignee: assignment.assignee, dueDate: assignment.dueDate ?? undefined }
+          : doc
+      )
+    );
+  }
+
+  upsertTask(task: Task): void {
+    this.tasks.update((prev) => {
+      const next = [...prev];
+      const index = next.findIndex((existing) => existing.id === task.id);
+      if (index >= 0) {
+        next[index] = { ...task };
+        return next;
+      }
+      next.push({ ...task });
+      return next;
+    });
+  }
+
   createTask(taskInput: Omit<Task, 'id'>): Task {
     const newTask: Task = {
       id: `task-${Math.random().toString(36).slice(2, 8)}`,
       ...taskInput
     };
-    this.tasks.update((prev) => [...prev, newTask]);
+    this.upsertTask(newTask);
     return newTask;
   }
 


### PR DESCRIPTION
## Summary
- add a scheduling wizard on the project deliverables page to guide responsible and due date assignments with visual feedback
- persist assignments and optional calendar tasks via backend endpoints and store updates, including API mappers and translations
- surface assignee and due date information in the deliverables table and launch the wizard automatically after project creation

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1901a1a1c83328aacd4764a7f63ee