### PR TITLE
Fix TypeScript private identifier modifiers in deliverables page

### DIFF
--- a/frontend/src/pages/Deliverables/deliverables-page.ts
+++ b/frontend/src/pages/Deliverables/deliverables-page.ts
@@ -55,7 +55,7 @@ export class DeliverablesPage extends LocalizedElement {
     this.#toastTimeouts.clear();
   }
 
-  private #readWizardFlag(): boolean {
+  #readWizardFlag(): boolean {
     try {
       const params = new URLSearchParams(window.location.search);
       return params.get('wizard') === 'schedule';
@@ -65,7 +65,7 @@ export class DeliverablesPage extends LocalizedElement {
     }
   }
 
-  private #clearWizardFlag(): void {
+  #clearWizardFlag(): void {
     try {
       const url = new URL(window.location.href);
       if (!url.searchParams.has('wizard')) {
@@ -80,7 +80,7 @@ export class DeliverablesPage extends LocalizedElement {
     }
   }
 
-  private #maybeOpenWizard(projectId: string): void {
+  #maybeOpenWizard(projectId: string): void {
     if (!this.#wizardAutoStart) {
       return;
     }
@@ -252,7 +252,7 @@ export class DeliverablesPage extends LocalizedElement {
     }
   }
 
-  private async #loadDeliverables(projectId: string): Promise<void> {
+  async #loadDeliverables(projectId: string): Promise<void> {
     this.#loadingFor = projectId;
     this.isLoading = true;
     this.loadError = null;


### PR DESCRIPTION
## Summary
- remove redundant accessibility modifiers from private identifier methods in the deliverables page to satisfy the TypeScript compiler

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1978fb1e08332b1c625597b2687fb