### PR TITLE
Handle invalid bearer tokens with anonymous fallback

### DIFF
--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -103,3 +103,15 @@ def test_legacy_token_without_sub_claim_is_accepted():
     response = client.post("/risk-evaluations", json={"answers": {}}, headers=headers)
 
     assert response.status_code == 200
+
+
+def test_invalid_token_falls_back_to_demo_user_when_allowed():
+    client = TestClient(_main_module.app)
+
+    response = client.post(
+        "/risk-evaluations",
+        json={"answers": {}},
+        headers={"Authorization": "Bearer not-a-valid-token"},
+    )
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- attempt to decode bearer tokens but fall back to the seeded demo user when anonymous access is enabled
- add a regression test covering the anonymous fallback path for invalid tokens hitting the risk evaluation endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e19cc83cec8332b1457940489cc82b