### PR TITLE
feat: allow editing account information in settings

### DIFF
--- a/frontend/src/pages/Settings/settings-page.ts
+++ b/frontend/src/pages/Settings/settings-page.ts
@@ -1,9 +1,13 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { AuthController } from '../../state/controllers';
 import { getNotificationSettings, type NotificationSetting } from './Settings.viewmodel';
 import { LocalizedElement } from '../../shared/localized-element';
-import { t } from '../../shared/i18n';
+import { supportedLanguages, t } from '../../shared/i18n';
+import type { ContactPreference, User } from '../../services/auth';
+import type { SupportedLanguage } from '../../shared/i18n';
+
+type ContactMethod = ContactPreference['method'];
 
 @customElement('settings-page')
 export class SettingsPage extends LocalizedElement {
@@ -12,6 +16,18 @@ export class SettingsPage extends LocalizedElement {
   private readonly auth = new AuthController(this);
 
   @state() private selected: Set<string> = new Set(['incidents', 'deliverables']);
+  @state() private fullName = '';
+  @state() private company = '';
+  @state() private avatar = '';
+  @state() private contactMethod: ContactMethod = 'email';
+  @state() private contactValue = '';
+  @state() private contactWorkspace = '';
+  @state() private contactChannel = '';
+  @state() private language: SupportedLanguage = supportedLanguages[0];
+  @state() private isSaving = false;
+  @state() private saveStatus: 'success' | 'error' | null = null;
+
+  private syncedUser: User | null = null;
 
   protected createRenderRoot(): HTMLElement {
     return this;
@@ -27,9 +43,106 @@ export class SettingsPage extends LocalizedElement {
     this.selected = next;
   }
 
+  protected override willUpdate(_changed: PropertyValues<this>): void {
+    const user = this.auth.user ?? null;
+    if (user !== this.syncedUser) {
+      this.syncFormWithUser(user);
+      this.syncedUser = user;
+    }
+  }
+
+  private syncFormWithUser(user: User | null): void {
+    if (!user) {
+      this.fullName = '';
+      this.company = '';
+      this.avatar = '';
+      this.contactMethod = 'email';
+      this.contactValue = '';
+      this.contactWorkspace = '';
+      this.contactChannel = '';
+      this.language = supportedLanguages[0];
+      this.saveStatus = null;
+      return;
+    }
+
+    const isDifferentUser = !this.syncedUser || this.syncedUser.id !== user.id;
+    this.fullName = user.full_name ?? '';
+    this.company = user.company ?? '';
+    this.avatar = user.avatar ?? '';
+    this.contactMethod = user.contact?.method ?? 'email';
+    this.contactValue = user.contact?.value ?? '';
+    this.contactWorkspace = user.contact?.workspace ?? '';
+    this.contactChannel = user.contact?.channel ?? '';
+    const preferredLanguage = user.preferences?.language;
+    this.language = supportedLanguages.includes(preferredLanguage as SupportedLanguage)
+      ? (preferredLanguage as SupportedLanguage)
+      : supportedLanguages[0];
+    if (isDifferentUser) {
+      this.saveStatus = null;
+    }
+  }
+
+  private get contactValueLabel(): string {
+    const labels: Record<ContactMethod, string> = {
+      email: t('auth.signup.contactEmail'),
+      sms: t('auth.signup.contactPhoneSms'),
+      whatsapp: t('auth.signup.contactPhoneWhatsapp'),
+      slack: t('auth.signup.contactSlackUser')
+    };
+    return labels[this.contactMethod];
+  }
+
+  private async handleAccountSubmit(event: Event): Promise<void> {
+    event.preventDefault();
+    const user = this.auth.user;
+    if (!user) {
+      return;
+    }
+
+    const trimmedName = this.fullName.trim();
+    const trimmedCompany = this.company.trim();
+    const trimmedAvatar = this.avatar.trim();
+    const trimmedContactValue = this.contactValue.trim();
+    const trimmedWorkspace = this.contactWorkspace.trim();
+    const trimmedChannel = this.contactChannel.trim();
+
+    const contact: ContactPreference = {
+      method: this.contactMethod,
+      value: trimmedContactValue
+    };
+
+    if (this.contactMethod === 'slack') {
+      if (trimmedWorkspace) {
+        contact.workspace = trimmedWorkspace;
+      }
+      if (trimmedChannel) {
+        contact.channel = trimmedChannel;
+      }
+    }
+
+    this.isSaving = true;
+    this.saveStatus = null;
+    try {
+      await this.auth.value.updateProfile({
+        full_name: trimmedName,
+        company: trimmedCompany || null,
+        avatar: trimmedAvatar || null,
+        contact,
+        preferences: { language: this.language }
+      });
+      this.saveStatus = 'success';
+    } catch (error) {
+      console.error('Failed to update profile', error);
+      this.saveStatus = 'error';
+    } finally {
+      this.isSaving = false;
+    }
+  }
+
   protected render() {
     const user = this.auth.user;
     const notifications = getNotificationSettings();
+    const hasUser = Boolean(user);
 
     return html`
       <section class="space-y-6">
@@ -39,11 +152,169 @@ export class SettingsPage extends LocalizedElement {
         </header>
 
         <article class="card bg-base-100 shadow">
-          <div class="card-body space-y-2">
-            <h2 class="card-title">${t('settings.account.title')}</h2>
-            <p class="text-sm text-base-content/70">${user?.email ?? t('settings.account.noSession')}</p>
-            <p class="text-sm">${user?.company ?? t('settings.account.noCompany')}</p>
-          </div>
+          <form class="card-body space-y-6" @submit=${this.handleAccountSubmit}>
+            <header class="flex flex-col gap-4 md:flex-row md:items-center">
+              <div class="avatar">
+                <div class="w-20 rounded-full ring ring-primary/20 ring-offset-base-100 ring-offset-2 overflow-hidden bg-base-200">
+                  ${this.avatar
+                    ? html`<img src=${this.avatar} alt=${t('settings.account.avatarAlt', { name: this.fullName || user?.full_name || '' })} />`
+                    : html`<div class="w-full h-full flex items-center justify-center text-2xl font-semibold text-base-content/60 bg-base-300">
+                        ${(this.fullName || user?.full_name || '?').slice(0, 1).toUpperCase()}
+                      </div>`}
+                </div>
+              </div>
+              <div class="space-y-1">
+                <h2 class="card-title">${t('settings.account.title')}</h2>
+                <p class="text-sm text-base-content/70">${t('settings.account.description')}</p>
+                <p class="text-sm">
+                  ${user?.email ?? t('settings.account.noSession')}
+                </p>
+              </div>
+            </header>
+
+            ${!hasUser
+              ? html`<div class="alert alert-info text-sm">${t('settings.account.noSession')}</div>`
+              : null}
+
+            ${this.saveStatus === 'success'
+              ? html`<div class="alert alert-success text-sm">${t('settings.account.feedback.success')}</div>`
+              : null}
+            ${this.saveStatus === 'error'
+              ? html`<div class="alert alert-error text-sm">${t('settings.account.feedback.error')}</div>`
+              : null}
+
+            <fieldset class="grid gap-4 md:grid-cols-2">
+              <label class="form-control">
+                <span class="label"><span class="label-text">${t('settings.account.fields.fullName')}</span></span>
+                <input
+                  class="input input-bordered"
+                  .value=${this.fullName}
+                  ?disabled=${!hasUser || this.isSaving}
+                  required
+                  @input=${(event: Event) => {
+                    const input = event.currentTarget as HTMLInputElement;
+                    this.fullName = input.value;
+                  }}
+                >
+              </label>
+              <label class="form-control">
+                <span class="label"><span class="label-text">${t('settings.account.fields.company')}</span></span>
+                <input
+                  class="input input-bordered"
+                  .value=${this.company}
+                  ?disabled=${!hasUser || this.isSaving}
+                  @input=${(event: Event) => {
+                    const input = event.currentTarget as HTMLInputElement;
+                    this.company = input.value;
+                  }}
+                >
+              </label>
+              <label class="form-control">
+                <span class="label"><span class="label-text">${t('settings.account.fields.email')}</span></span>
+                <input class="input input-bordered" .value=${user?.email ?? ''} disabled>
+              </label>
+              <label class="form-control">
+                <span class="label"><span class="label-text">${t('settings.account.fields.avatar')}</span></span>
+                <input
+                  class="input input-bordered"
+                  .value=${this.avatar}
+                  ?disabled=${!hasUser || this.isSaving}
+                  placeholder="https://"
+                  @input=${(event: Event) => {
+                    const input = event.currentTarget as HTMLInputElement;
+                    this.avatar = input.value;
+                  }}
+                >
+                <span class="label"><span class="label-text-alt text-xs">${t('settings.account.fields.avatarHint')}</span></span>
+              </label>
+            </fieldset>
+
+            <fieldset class="grid gap-4 md:grid-cols-2">
+              <label class="form-control">
+                <span class="label"><span class="label-text">${t('settings.account.fields.contactMethod')}</span></span>
+                <select
+                  class="select select-bordered"
+                  .value=${this.contactMethod}
+                  ?disabled=${!hasUser || this.isSaving}
+                  @change=${(event: Event) => {
+                    const select = event.currentTarget as HTMLSelectElement;
+                    this.contactMethod = select.value as ContactMethod;
+                  }}
+                >
+                  <option value="email">${t('auth.contactMethods.email')}</option>
+                  <option value="sms">${t('auth.contactMethods.sms')}</option>
+                  <option value="whatsapp">${t('auth.contactMethods.whatsapp')}</option>
+                  <option value="slack">${t('auth.contactMethods.slack')}</option>
+                </select>
+              </label>
+              <label class="form-control">
+                <span class="label"><span class="label-text">${this.contactValueLabel}</span></span>
+                <input
+                  class="input input-bordered"
+                  .value=${this.contactValue}
+                  ?disabled=${!hasUser || this.isSaving}
+                  required
+                  @input=${(event: Event) => {
+                    const input = event.currentTarget as HTMLInputElement;
+                    this.contactValue = input.value;
+                  }}
+                >
+              </label>
+              ${this.contactMethod === 'slack'
+                ? html`
+                    <label class="form-control">
+                      <span class="label"><span class="label-text">${t('auth.signup.slackWorkspace')}</span></span>
+                      <input
+                        class="input input-bordered"
+                        .value=${this.contactWorkspace}
+                        ?disabled=${!hasUser || this.isSaving}
+                        @input=${(event: Event) => {
+                          const input = event.currentTarget as HTMLInputElement;
+                          this.contactWorkspace = input.value;
+                        }}
+                      >
+                    </label>
+                    <label class="form-control">
+                      <span class="label"><span class="label-text">${t('auth.signup.slackChannel')}</span></span>
+                      <input
+                        class="input input-bordered"
+                        .value=${this.contactChannel}
+                        ?disabled=${!hasUser || this.isSaving}
+                        @input=${(event: Event) => {
+                          const input = event.currentTarget as HTMLInputElement;
+                          this.contactChannel = input.value;
+                        }}
+                      >
+                    </label>
+                  `
+                : null}
+            </fieldset>
+
+            <fieldset class="grid gap-4 md:grid-cols-2">
+              <label class="form-control">
+                <span class="label"><span class="label-text">${t('settings.account.fields.language')}</span></span>
+                <select
+                  class="select select-bordered"
+                  .value=${this.language}
+                  ?disabled=${!hasUser || this.isSaving}
+                  @change=${(event: Event) => {
+                    const select = event.currentTarget as HTMLSelectElement;
+                    this.language = (select.value as SupportedLanguage);
+                  }}
+                >
+                  ${supportedLanguages.map(
+                    (language) => html`<option value=${language}>${t(`languages.${language}.full`)}</option>`
+                  )}
+                </select>
+              </label>
+            </fieldset>
+
+            <div class="flex justify-end">
+              <button class="btn btn-primary" type="submit" ?disabled=${!hasUser || this.isSaving}>
+                ${this.isSaving ? t('settings.account.actions.saving') : t('settings.account.actions.save')}
+              </button>
+            </div>
+          </form>
         </article>
 
         <section class="space-y-4">

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -84,6 +84,14 @@ export interface SignInVerificationResendPayload {
   registration_id: string
 }
 
+export interface UpdateProfilePayload {
+  full_name: string
+  company?: string | null
+  avatar?: string | null
+  contact: ContactPreference
+  preferences: UserPreferences
+}
+
 export function login(payload: LoginPayload) {
   return api<LoginResponse>(LOGIN_ENDPOINT, {
     method: 'POST',
@@ -121,4 +129,11 @@ export function resendSignInCode(payload: SignInVerificationResendPayload) {
 
 export function fetchCurrentUser(token?: string) {
   return api<User>(PROFILE_ENDPOINT, undefined, token)
+}
+
+export function updateProfile(payload: UpdateProfilePayload) {
+  return api<User>(PROFILE_ENDPOINT, {
+    method: 'PATCH',
+    body: JSON.stringify(payload)
+  })
 }

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -454,8 +454,27 @@ const resources = {
         title: "Ajustes de la aplicación",
         account: {
           title: "Cuenta",
+          description: "Actualiza la información visible para tu organización.",
           noSession: "Sin sesión activa",
-          noCompany: "Organización no definida"
+          noCompany: "Organización no definida",
+          avatarAlt: "Avatar de {{name}}",
+          fields: {
+            fullName: "Nombre completo",
+            company: "Empresa",
+            email: "Correo de acceso",
+            avatar: "Avatar (URL)",
+            avatarHint: "Pega la URL de una imagen cuadrada o deja vacío para usar las iniciales.",
+            contactMethod: "Canal preferido",
+            language: "Idioma de la interfaz"
+          },
+          actions: {
+            save: "Guardar cambios",
+            saving: "Guardando…"
+          },
+          feedback: {
+            success: "Perfil actualizado correctamente.",
+            error: "No se pudieron guardar los cambios."
+          }
         },
         preferences: {
           title: "Preferencias",
@@ -1123,8 +1142,27 @@ const resources = {
         title: "Application settings",
         account: {
           title: "Account",
+          description: "Keep your profile information up to date for your team.",
           noSession: "No active session",
-          noCompany: "Organization not defined"
+          noCompany: "Organization not defined",
+          avatarAlt: "Avatar of {{name}}",
+          fields: {
+            fullName: "Full name",
+            company: "Company",
+            email: "Login email",
+            avatar: "Avatar (URL)",
+            avatarHint: "Paste the URL of a square image or leave empty to use initials.",
+            contactMethod: "Preferred channel",
+            language: "Interface language"
+          },
+          actions: {
+            save: "Save changes",
+            saving: "Saving…"
+          },
+          feedback: {
+            success: "Profile updated successfully.",
+            error: "We couldn't save your changes."
+          }
         },
         preferences: {
           title: "Preferences",
@@ -1896,8 +1934,27 @@ const resources = {
         title: "Ajustos de l'aplicació",
         account: {
           title: "Compte",
+          description: "Actualitza la informació visible per al teu equip.",
           noSession: "Sense sessió activa",
-          noCompany: "Organització no definida"
+          noCompany: "Organització no definida",
+          avatarAlt: "Avatar de {{name}}",
+          fields: {
+            fullName: "Nom complet",
+            company: "Empresa",
+            email: "Correu d'accés",
+            avatar: "Avatar (URL)",
+            avatarHint: "Enganxa l'URL d'una imatge quadrada o deixa-ho buit per usar les inicials.",
+            contactMethod: "Canal preferit",
+            language: "Llengua de la interfície"
+          },
+          actions: {
+            save: "Desa els canvis",
+            saving: "Desant…"
+          },
+          feedback: {
+            success: "Perfil actualitzat correctament.",
+            error: "No s'han pogut desar els canvis."
+          }
         },
         preferences: {
           title: "Preferències",
@@ -2669,8 +2726,27 @@ const resources = {
         title: "Paramètres de l'application",
         account: {
           title: "Compte",
+          description: "Mettez à jour les informations visibles par votre organisation.",
           noSession: "Aucune session active",
-          noCompany: "Organisation non définie"
+          noCompany: "Organisation non définie",
+          avatarAlt: "Avatar de {{name}}",
+          fields: {
+            fullName: "Nom complet",
+            company: "Entreprise",
+            email: "E-mail de connexion",
+            avatar: "Avatar (URL)",
+            avatarHint: "Collez l'URL d'une image carrée ou laissez vide pour utiliser les initiales.",
+            contactMethod: "Canal préféré",
+            language: "Langue de l'interface"
+          },
+          actions: {
+            save: "Enregistrer les modifications",
+            saving: "Enregistrement…"
+          },
+          feedback: {
+            success: "Profil mis à jour avec succès.",
+            error: "Impossible d'enregistrer les modifications."
+          }
         },
         preferences: {
           title: "Préférences",

--- a/frontend/src/state/auth-store.ts
+++ b/frontend/src/state/auth-store.ts
@@ -5,6 +5,7 @@ import {
   resendSignInCode,
   signIn,
   verifySignIn,
+  updateProfile,
   type LoginPayload,
   type LoginResponse,
   type SignInPayload,
@@ -13,6 +14,7 @@ import {
   type SignInVerificationResendPayload,
   type SignInVerificationResponse,
   type SSOLoginPayload,
+  type UpdateProfilePayload,
   type User
 } from '../services/auth';
 import { clearStoredAuth, readStoredAuth, storeAuthState } from '../shared/auth-storage';
@@ -92,6 +94,16 @@ export class AuthStore {
 
   async resendRegistrationCode(payload: SignInVerificationResendPayload): Promise<SignInResponse> {
     return this.#runAuthAction(async () => resendSignInCode(payload));
+  }
+
+  async updateProfile(payload: UpdateProfilePayload): Promise<User> {
+    if (!this.token.value) {
+      throw new Error('Not authenticated');
+    }
+    const user = await updateProfile(payload);
+    this.user.value = user;
+    storeAuthState({ token: this.token.value, user });
+    return user;
   }
 
   logout(): void {


### PR DESCRIPTION
## Summary
- add an authenticated profile update API and store helper
- turn the settings account section into an editable profile form with avatar, contact and language controls
- extend i18n resources to cover the new account fields across supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e24a87887483329b6e0f23f71c3ba2