### PR TITLE
Fix incidents page loading state

### DIFF
--- a/frontend/src/components/app-header.ts
+++ b/frontend/src/components/app-header.ts
@@ -17,12 +17,33 @@ const styles = css`
 export class AppHeader extends LocalizedElement {
   static override styles = [css([sharedStyles] as any), styles];
 
-  @property({ attribute: false }) activeProject: AISystem | null = null;
-  @property({ type: String }) language: SupportedLanguage = 'en';
-  @property({ attribute: false }) supportedLanguages: ReadonlyArray<SupportedLanguage> = [];
-  @property({ type: String }) userFullName: string | null = null;
-  @property({ type: String }) userEmail: string | null = null;
-  @property({ type: Boolean }) mobileMenuOpen = false;
+  @property({ attribute: false })
+  declare activeProject: AISystem | null;
+
+  @property({ type: String })
+  declare language: SupportedLanguage;
+
+  @property({ attribute: false })
+  declare supportedLanguages: ReadonlyArray<SupportedLanguage>;
+
+  @property({ type: String })
+  declare userFullName: string | null;
+
+  @property({ type: String })
+  declare userEmail: string | null;
+
+  @property({ type: Boolean })
+  declare mobileMenuOpen: boolean;
+
+  constructor() {
+    super();
+    this.activeProject = null;
+    this.language = 'en';
+    this.supportedLanguages = [];
+    this.userFullName = null;
+    this.userEmail = null;
+    this.mobileMenuOpen = false;
+  }
 
   private getUserInitials() {
     const nameSource = this.userFullName?.trim();
@@ -68,7 +89,7 @@ export class AppHeader extends LocalizedElement {
     this.dispatchEvent(new CustomEvent('logout', { bubbles: true, composed: true }));
   }
 
-    private toggleMenu() {
+  private toggleMenu() {
     this.dispatchEvent(new CustomEvent('toggle-menu', { bubbles: true, composed: true }));
   }
 

--- a/frontend/src/components/app-shell.ts
+++ b/frontend/src/components/app-shell.ts
@@ -23,10 +23,25 @@ export class AppShell extends LocalizedElement {
   private readonly auth = new AuthController(this);
   private readonly projects = new ProjectController(this);
 
-  @state() private mobileMenuOpen = false;
-  @state() private language = getCurrentLanguage();
-  @state() private isOnline = navigator.onLine;
-  @state() private activePath = getCurrentPath();
+  @state()
+  declare private mobileMenuOpen: boolean;
+
+  @state()
+  declare private language: SupportedLanguage;
+
+  @state()
+  declare private isOnline: boolean;
+
+  @state()
+  declare private activePath: string;
+
+  constructor() {
+    super();
+    this.mobileMenuOpen = false;
+    this.language = getCurrentLanguage();
+    this.isOnline = typeof navigator !== 'undefined' ? navigator.onLine : true;
+    this.activePath = getCurrentPath();
+  }
 
   private readonly updateOnlineStatus = () => {
     this.isOnline = navigator.onLine;

--- a/frontend/src/components/app-sidebar.ts
+++ b/frontend/src/components/app-sidebar.ts
@@ -63,11 +63,29 @@ const PROJECT_NAV_ITEMS: ReadonlyArray<ProjectNavigationItem> = [
 export class AppSidebar extends LocalizedElement {
   static override styles = [css([sharedStyles] as any), baseStyles];
 
-  @property({ type: Boolean }) mobileMenuOpen = false;
-  @property({ attribute: false }) activeProject: AISystem | null = null;
-  @property({ attribute: false }) projects: ReadonlyArray<AISystem> = [];
-  @property({ attribute: false }) activeProjectId: string | null = null;
-  @property({ type: String }) activePath = '/';
+  @property({ type: Boolean })
+  declare mobileMenuOpen: boolean;
+
+  @property({ attribute: false })
+  declare activeProject: AISystem | null;
+
+  @property({ attribute: false })
+  declare projects: ReadonlyArray<AISystem>;
+
+  @property({ attribute: false })
+  declare activeProjectId: string | null;
+
+  @property({ type: String })
+  declare activePath: string;
+
+  constructor() {
+    super();
+    this.mobileMenuOpen = false;
+    this.activeProject = null;
+    this.projects = [];
+    this.activeProjectId = null;
+    this.activePath = '/';
+  }
 
   private handleNavigate(event: Event, href: string) {
     event.preventDefault();

--- a/frontend/src/pages/Incidents/incidents-page.ts
+++ b/frontend/src/pages/Incidents/incidents-page.ts
@@ -22,10 +22,21 @@ export class IncidentsPage extends LocalizedElement {
     return t(`incident.status.${status}` as const);
   }
 
-  @property({ type: String, attribute: 'project-id' }) projectId = '';
+  @property({ type: String, attribute: 'project-id' })
+  declare projectId: string | null;
 
-  @state() private incidents: IncidentRow[] = [];
-  @state() private loading = false;
+  @state()
+  declare private incidents: IncidentRow[];
+
+  @state()
+  declare private loading: boolean;
+
+  constructor() {
+    super();
+    this.projectId = null;
+    this.incidents = [];
+    this.loading = false;
+  }
 
   protected createRenderRoot(): HTMLElement {
     return this;


### PR DESCRIPTION
## Summary
- avoid Lit class field shadowing on incidents-page reactive properties and initialize them safely
- update app-shell, app-header, and app-sidebar to declare reactive fields with explicit constructors so updates propagate
- ensure the incidents list renders after loading instead of staying on the spinner

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e24ac0f0748332abefad54bce2c3b1