### PR TITLE
Ensure legacy projects tables gain owner column on init

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -51,6 +51,13 @@ def init_db() -> None:
 
     if inspector.has_table("projects"):
         project_columns = {column["name"] for column in inspector.get_columns("projects")}
+        if "owner" not in project_columns:
+            with engine.connect() as connection:
+                if is_sqlite:
+                    connection.execute(text("ALTER TABLE projects ADD COLUMN owner VARCHAR(255)"))
+                else:
+                    connection.execute(text("ALTER TABLE projects ADD COLUMN owner VARCHAR(255)"))
+                connection.commit()
         if "purpose" not in project_columns:
             with engine.connect() as connection:
                 if is_sqlite:

--- a/tests/test_database_schema.py
+++ b/tests/test_database_schema.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from sqlalchemy import inspect, text
 
 
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
 def test_init_db_adds_missing_purpose_column(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "legacy.db"
     monkeypatch.setenv("SQLITE_DB_PATH", str(db_path))
@@ -41,3 +46,41 @@ def test_init_db_adds_missing_purpose_column(tmp_path, monkeypatch):
     inspector = inspect(database_module.engine)
     project_columns = {column["name"] for column in inspector.get_columns("projects")}
     assert "purpose" in project_columns
+
+
+def test_init_db_adds_missing_owner_column(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "legacy_owner.db"
+    monkeypatch.setenv("SQLITE_DB_PATH", str(db_path))
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    database_module = reload(import_module("backend.database"))
+    sys.modules.pop("backend.models", None)
+    import_module("backend.models")
+
+    with database_module.engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE projects (
+                    id VARCHAR(36) PRIMARY KEY,
+                    name VARCHAR(255) NOT NULL,
+                    role VARCHAR(50) NOT NULL,
+                    purpose VARCHAR(512),
+                    risk VARCHAR(50),
+                    documentation_status VARCHAR(50),
+                    business_units JSON,
+                    team JSON,
+                    deployments JSON,
+                    initial_risk_assessment JSON,
+                    created_at TIMESTAMP WITH TIME ZONE,
+                    updated_at TIMESTAMP WITH TIME ZONE
+                )
+                """
+            )
+        )
+
+    database_module.init_db()
+
+    inspector = inspect(database_module.engine)
+    project_columns = {column["name"] for column in inspector.get_columns("projects")}
+    assert "owner" in project_columns


### PR DESCRIPTION
## Summary
- extend `init_db` to backfill the `owner` column when upgrading legacy databases
- add regression coverage that recreates a legacy projects table and confirms the column is added
- make the schema tests importable by ensuring the repository root is on `sys.path`

## Testing
- pytest tests/test_database_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68e2516c4f408332a5558321653b68eb